### PR TITLE
ui: Allow creation of hub zones

### DIFF
--- a/ui/src/pages/Zones.tsx
+++ b/ui/src/pages/Zones.tsx
@@ -10,6 +10,7 @@ import {
     Show,
     SimpleShowLayout,
     BooleanField,
+    BooleanInput,
 } from 'react-admin';
 
 export const ZoneList = () => (
@@ -50,6 +51,7 @@ export const ZoneCreate = () => (
             <TextInput label="Name" source="name" />
             <TextInput label="Description" source="description" />
             <TextInput label="CIDR" source="cidr" />
+            <BooleanInput label="Hub Zone" source="hub_zone" />
         </SimpleForm>
     </Create>
 );


### PR DESCRIPTION
The Create Zone UI now has a boolean selector for setting the new zone as a Hub Zone.

Signed-off-by: Russell Bryant <rbryant@redhat.com>