### PR TITLE
ui: Drop ID from Zone list

### DIFF
--- a/ui/src/pages/Zones.tsx
+++ b/ui/src/pages/Zones.tsx
@@ -15,7 +15,6 @@ import {
 export const ZoneList = () => (
     <List>
         <Datagrid rowClick="show" bulkActionButtons={false}>
-            <TextField label="ID" source="id" />
             <TextField label="Name" source="name" />
             <TextField label="Description" source="description" />
             <TextField label="CIDR" source="cidr" />


### PR DESCRIPTION
Zones already have a friendly name, so drop the ID from the Zone list UI. The ID can still be viewed on the Zone detail view after a Zone is selected.

Signed-off-by: Russell Bryant <rbryant@redhat.com>