### PR TITLE
apex: Send controller the hostname for a device

### DIFF
--- a/internal/client/device.go
+++ b/internal/client/device.go
@@ -16,9 +16,10 @@ const (
 	DEVICE  = "/api/devices/%s"
 )
 
-func (c *Client) CreateDevice(publicKey string) (models.Device, error) {
+func (c *Client) CreateDevice(publicKey string, hostname string) (models.Device, error) {
 	body, err := json.Marshal(models.AddDevice{
 		PublicKey: publicKey,
+		Hostname:  hostname,
 	})
 	if err != nil {
 		return models.Device{}, err

--- a/internal/handlers/device.go
+++ b/internal/handlers/device.go
@@ -114,6 +114,7 @@ func (api *API) CreateDevice(c *gin.Context) {
 	device = models.Device{
 		PublicKey: request.PublicKey,
 		UserID:    user.ID,
+		Hostname:  request.Hostname,
 	}
 
 	if res := api.db.Create(&device); res.Error != nil {

--- a/internal/models/device.go
+++ b/internal/models/device.go
@@ -12,6 +12,7 @@ type Device struct {
 	PublicKey string      `gorm:"uniqueIndex" json:"public_key"`
 	Peers     []*Peer     `json:"-"`
 	PeerList  []uuid.UUID `gorm:"-" json:"peers" example:"97d5214a-8c51-4772-b492-53de034740c5"`
+	Hostname  string      `json:"hostname" example:"myhost"`
 }
 
 func (d *Device) BeforeCreate(tx *gorm.DB) error {
@@ -27,4 +28,5 @@ func (d *Device) BeforeCreate(tx *gorm.DB) error {
 // AddDevice is the information needed to add a new Device.
 type AddDevice struct {
 	PublicKey string `json:"public_key" example:"rZlVfefGshRxO+r9ethv2pODimKlUeP/bO/S47K3WUk="`
+	Hostname  string `json:"hostname" example:"myhost"`
 }

--- a/ui/src/pages/Devices.tsx
+++ b/ui/src/pages/Devices.tsx
@@ -14,7 +14,7 @@ import {
 export const DeviceList = () => (
     <List>
         <Datagrid rowClick="show" bulkActionButtons={false}>
-            <TextField label = "ID" source="id" />
+            <TextField label = "Hostname" source="hostname" />
             <ReferenceField label = "User" source="user_id" reference="users" link="show"/>
             <TextField label = "Public Key" source="public_key" />
             <ReferenceArrayField label="Peers" source="peers" reference="peers">
@@ -30,6 +30,7 @@ export const DeviceShow = () => (
     <Show>
         <SimpleShowLayout>
             <TextField label="ID" source="id" />
+            <TextField label = "Hostname" source="hostname" />
             <ReferenceField label = "User" source="user_id" reference="users" link="show"/>
             <TextField label = "Public Key" source="public_key" />
             <ReferenceArrayField label="Peers" source="peers" reference="peers">


### PR DESCRIPTION
Have the apex client send the Hostname to the controller when creating a new Device.

In the UI, replace the Device ID with the Device's Hostname in the Device list. The ID is still visible in the Device details page.

Signed-off-by: Russell Bryant <rbryant@redhat.com>