### PR TITLE
Make apex spawnable in IT containers

### DIFF
--- a/Containerfile.test
+++ b/Containerfile.test
@@ -1,7 +1,7 @@
 FROM alpine:3.16 as alpine
 RUN apk add --no-cache iputils wireguard-tools iptables psmisc
 COPY ./dist/apex /bin/apex
-ENTRYPOINT [ "/bin/bash" ]
+ENTRYPOINT [ "/bin/sh" ]
 
 FROM fedora:36 as fedora
 RUN dnf update -qy && \
@@ -16,7 +16,7 @@ RUN dnf update -qy && \
     && \
     dnf clean all
 COPY ./dist/apex /bin/apex
-CMD [ "/bin/bash" ]
+ENTRYPOINT [ "/bin/sh" ]
 
 FROM ubuntu:22.04 as ubuntu
 ENV DEBIAN_FRONTEND=noninteractive
@@ -30,4 +30,4 @@ RUN apt-get update -qy && \
     && \
     apt-get clean
 COPY ./dist/apex /bin/apex
-ENTRYPOINT [ "/bin/bash" ]
+ENTRYPOINT [ "/bin/sh" ]

--- a/Containerfile.test
+++ b/Containerfile.test
@@ -1,7 +1,7 @@
 FROM alpine:3.16 as alpine
 RUN apk add --no-cache iputils wireguard-tools iptables psmisc
 COPY ./dist/apex /bin/apex
-ENTRYPOINT [ "/bin/apex" ]
+ENTRYPOINT [ "/bin/bash" ]
 
 FROM fedora:36 as fedora
 RUN dnf update -qy && \
@@ -16,7 +16,7 @@ RUN dnf update -qy && \
     && \
     dnf clean all
 COPY ./dist/apex /bin/apex
-ENTRYPOINT [ "/bin/apex" ]
+CMD [ "/bin/bash" ]
 
 FROM ubuntu:22.04 as ubuntu
 ENV DEBIAN_FRONTEND=noninteractive
@@ -30,4 +30,4 @@ RUN apt-get update -qy && \
     && \
     apt-get clean
 COPY ./dist/apex /bin/apex
-ENTRYPOINT [ "/bin/apex" ]
+ENTRYPOINT [ "/bin/bash" ]

--- a/internal/client/user.go
+++ b/internal/client/user.go
@@ -67,7 +67,7 @@ func (c *Client) MoveCurrentUserToZone(zoneID uuid.UUID) (models.User, error) {
 
 	defer res.Body.Close()
 
-        body, err := io.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return models.User{}, err
 	}
@@ -75,10 +75,10 @@ func (c *Client) MoveCurrentUserToZone(zoneID uuid.UUID) (models.User, error) {
 		return models.User{}, fmt.Errorf("failed to patch the user into the zone: %s", zoneID)
 	}
 
-        var u models.User
+	var u models.User
 	if err := json.Unmarshal(body, &u); err != nil {
 		return models.User{}, err
 	}
-	
+
 	return u, nil
 }


### PR DESCRIPTION
- Changed Containerfile.test to run a shell to allow for stopping and restarting of Apex from IT.
- Enabled go-e2e to run in CI.
- Added restart and key deletion tests.
- Added create network in utils to prep for building out a NAT topology for testing symetric NAT.

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>