### PR TITLE
Makefile: Add recompose target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,3 +81,9 @@ e2e: dist/apex
 go-e2e: dist/apex test-images
 	docker compose up --build -d
 	go test -v --tags=integration ./integration-tests/...
+
+.PHONY: recompose
+recompose: dist/apex
+	docker-compose down
+	docker-compose build
+	docker-compose up -d


### PR DESCRIPTION
While the docker-compose env is still around, this adds a target that's a shortcut for rebuilding the test environment - down/build/up.

Signed-off-by: Russell Bryant <rbryant@redhat.com>