### PR TITLE
ui: Improve title to PeerShow page

### DIFF
--- a/ui/src/pages/Peers.tsx
+++ b/ui/src/pages/Peers.tsx
@@ -1,4 +1,15 @@
-import { Datagrid, List, ReferenceField, Show, SimpleShowLayout, TextField, ReferenceInput } from 'react-admin';
+import {
+    Datagrid,
+    List,
+    ReferenceField,
+    Show,
+    SimpleShowLayout,
+    TextField,
+    ReferenceInput,
+    useRecordContext,
+    useGetOne,
+    Loading,
+} from 'react-admin';
 
 const peerFilters =  [
     <ReferenceInput source="device_id" label="Device" reference="devices" />,
@@ -18,8 +29,18 @@ export const PeerList = () => (
     </List>
 );
 
+const PeerTitle = () => {
+    const peer = useRecordContext();
+    if (!peer) return null;
+    const { data: zone, isLoading, error } = useGetOne('zones', { id: peer.zone_id });
+    const { data: device, isLoading: isLoading2, error: error2 } = useGetOne('devices', { id: peer.device_id });
+    if (isLoading || isLoading2) { return <Loading />; }
+    if (error || error2) { return <p>ERROR</p>; }
+    return <div>Peer: Device {device.hostname} to Zone {zone.name}</div>;
+};
+
 export const PeerShow= () => (
-    <Show>
+    <Show title={<PeerTitle />}>
         <SimpleShowLayout>
             <TextField label="ID" source="id" />
             <ReferenceField label="Device" source="device_id" reference='devices' link="show" />


### PR DESCRIPTION
The previous title for the Peer Show page was "Peer #<id>". The titles for all other pages was updated to a more friendly representation by changing the recordRepresentation on the Resource. I wasn't able to get that to work for peers.

Instead, this just explicitly updates the title for the page showing
details of a single peer. Now the title shows "Peer: Device <device>
to Zone <zone>."

There are no other places at the moment that would benefit from updating the recordRepresentation for peers, so this seems good enough.

Signed-off-by: Russell Bryant <rbryant@redhat.com>