### PR TITLE
Adds full mesh capabilities via reflexive addresses

### DIFF
--- a/cmd/apex/main.go
+++ b/cmd/apex/main.go
@@ -42,7 +42,7 @@ func main() {
 			},
 			&cli.IntFlag{
 				Name:     "listen-port",
-				Value:    51820,
+				Value:    0,
 				Usage:    "port wireguard is to listen for incoming peers on",
 				EnvVars:  []string{"APEX_LISTEN_PORT"},
 				Required: false,
@@ -78,6 +78,12 @@ func main() {
 				Usage:    "set if this node is to be the hub in a hub and spoke deployment",
 				Value:    false,
 				EnvVars:  []string{"APEX_HUB_ROUTER"},
+				Required: false,
+			},
+			&cli.BoolFlag{Name: "relay-only",
+				Usage:    "set if this node is unable to NAT hole punch in a hub zone (Apex will set this automatically if symmetric NAT is detected)",
+				Value:    false,
+				EnvVars:  []string{"APEX_RELAY_ONLY"},
 				Required: false,
 			},
 			&cli.StringFlag{

--- a/docs/design/design-discovery.md
+++ b/docs/design/design-discovery.md
@@ -43,7 +43,7 @@ Discovery is a key component of Apex. Enterprise workloads are spread across all
 ## Current and Future Discovery Plans
 
 > **Warning**
-> Current peer discovery is still in an early POC state.
+> Current peer discovery is still in an early POC state. All discovery scenarios are subject to change.
 
 ### Nodes without a firewall and/or NAT device between them (currently supported)
 
@@ -51,7 +51,7 @@ Discovery is a key component of Apex. Enterprise workloads are spread across all
 - This means that when both nodes share the same public or "reflexive address" (as defined in the above figure), Apex assumes that other peers are likely to have direct access to one another. Each peer has their stun/reflexive address in the peer listing received from the controller.
 - Next, the Apex agent will look up the "Local Address" (see Figure 1) of a peer candidate in the peer listing and attempt to probe for connectivity. If this probing succeeds, we consider it a likely candidate match, and both peers set up the connection to one another with a /32 host route and wireguard tunnel.
 
-### Nodes with a firewall and/or NAT device between them (currently in progress)
+### Nodes with a firewall and/or NAT device between them (currently supported)
 
 ```
                                +---------+
@@ -69,13 +69,14 @@ Discovery is a key component of Apex. Enterprise workloads are spread across all
                       /                             \
                      /                               \
                  +-------+                       +-------+
-                 | Agent |                       | Agent |
-                 |   L   |                       |   R   |
+                 | Agent | Encrypted Connection  | Agent |
+                 |   L   | ====================  |   R   |
                  +-------+                       +-------+
 ```
 
-*Figure 2 - NAT traversal connecting directly via reflexive addresses sockets learned via STUN*
+*Figure 2. NAT traversal connecting directly via reflexive addresses sockets learned via STUN*
 
+- Current discovery of valid sockets is gathered from a relay node that all peers can attach to. That state is distributed to all peer nodes (except for symmetric NAT nodes that will use the relay to reach all other nodes).
 - Two endpoints that do not match the initial local address peering, will attempt to peer via the STUN method (see the ICE RFC or the STUN [RFC3489](https://www.ietf.org/rfc/rfc3489.txt) for further details regarding the STUN protocol). A STUN request can be used to open a source UDP port on the NAT device front-ending the endpoint.
 - A STUN server allows nodes to discover their public address, the type of NAT they are behind and the Internet side port associated by the NAT with a particular local port. This information is used to set up a UDP connection between the two peers behind the NAT device.
 - That UDP source port will remain open for some unknown period of time (depending on the NAT device).

--- a/internal/apex/configure-utils.go
+++ b/internal/apex/configure-utils.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	WgListenPort      = 51820
+	WgDefaultPort     = 51820
 	WgLinuxConfPath   = "/etc/wireguard/"
 	WgDarwinConfPath  = "/usr/local/etc/wireguard/"
 	WgWindowsConfPath = "C:/"

--- a/internal/apex/discovery.go
+++ b/internal/apex/discovery.go
@@ -39,7 +39,7 @@ func probePeers(peers []string) []string {
 		result[i] = <-c
 		if result[i].status {
 			reachablePeers = append(reachablePeers, result[i].peer)
-			log.Debugf("peer [ %s ] is reachable", result[i].peer)
+			log.Tracef("peer [ %s ] is reachable", result[i].peer)
 		} else {
 			log.Debugf("peer [ %s ] is not reachable", result[i].peer)
 		}

--- a/internal/apex/dump.go
+++ b/internal/apex/dump.go
@@ -1,0 +1,85 @@
+package apex
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// WgSessions wireguard peer session information
+type WgSessions struct {
+	PublicKey       string
+	PreSharedKey    string
+	Endpoint        string
+	AllowedIPs      []string
+	LatestHandshake string
+	Tx              int
+	Rx              int
+}
+
+// ShowDump wireguard interface dump
+func ShowDump(iface string) (string, error) {
+	dumpOut, err := RunCommand("wg", "show", iface, "dump")
+	if err != nil {
+		return "", fmt.Errorf("failed to dump wireguard peers %v", err)
+	}
+
+	return dumpOut, nil
+}
+
+// DumpPeers dump wireguard peers
+func DumpPeers(iface string) ([]WgSessions, error) {
+	result, err := ShowDump(iface)
+	if err != nil {
+		return nil, fmt.Errorf("error running wg show %s dump :%v", iface, err)
+	}
+	r := bufio.NewReader(strings.NewReader(result))
+	peers := make([]WgSessions, 0)
+	for {
+		line, _, err := r.ReadLine()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("failed to read wg dump: %v", err)
+		}
+		column := strings.Split(string(line), "	")
+		if len(column) != 8 {
+			continue
+		}
+		publicKey := column[0]
+		psk := column[1]
+		endpoints := column[2]
+		allowedIPs := strings.Split(column[3], ",")
+		latestHandshake, err := strconv.Atoi(column[4])
+		if err != nil {
+			return nil, fmt.Errorf("latest handshake parse failed: %v", err)
+		}
+		latestHandshakeTime := time.Duration(0)
+		if latestHandshake != 0 {
+			latestHandshakeTime = time.Since(time.Unix(int64(latestHandshake), 0))
+		}
+		tx, err := strconv.Atoi(column[5])
+		if err != nil {
+			return nil, fmt.Errorf("transfer received parse failed: %v", err)
+		}
+		tr, err := strconv.Atoi(column[6])
+		if err != nil {
+			return nil, fmt.Errorf("transfer sent parse failed: %v", err)
+		}
+		peers = append(peers, WgSessions{
+			PublicKey:       publicKey,
+			PreSharedKey:    psk,
+			Endpoint:        endpoints,
+			AllowedIPs:      allowedIPs,
+			LatestHandshake: latestHandshakeTime.String(),
+			Tx:              tx,
+			Rx:              tr,
+		})
+	}
+
+	return peers, nil
+}

--- a/internal/apex/stun.go
+++ b/internal/apex/stun.go
@@ -1,0 +1,95 @@
+package apex
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/pion/stun"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	stunServer1 = "stun1.l.google.com:19302"
+	stunServer2 = "stun2.l.google.com:19302"
+)
+
+// IsSymmetricNAT attempts to infer if the node is behind a symmetric
+// nat device by querying two STUN servers. If the requests return
+// different ports, then it is likely the node is behind a symmetric nat.
+func IsSymmetricNAT() (bool, error) {
+	// get a random port to source the request from since the wg port may be bound
+	srcPort := getWgListenPort()
+	firstStun, err := StunRequest(stunServer1, srcPort)
+	if err != nil {
+		return false, fmt.Errorf("failed to queury the STUN server %s", stunServer1)
+	}
+	secondStun, err := StunRequest(stunServer2, srcPort)
+	if err != nil {
+		return false, fmt.Errorf("failed to queury the STUN server %s", stunServer1)
+	}
+	if firstStun != secondStun {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// StunRequest initiate a connection to a STUN server sourced from the wg src port
+func StunRequest(stunServer string, srcPort int) (string, error) {
+	lAddr := &net.UDPAddr{
+		Port: srcPort,
+	}
+	d := &net.Dialer{
+		Timeout:   3 * time.Second,
+		LocalAddr: lAddr,
+	}
+	log.Debugf("dialing stun server %s", stunServer)
+	conn, err := d.Dial("udp4", stunServer)
+	if err != nil {
+		log.Errorf("stun dialing timed out %v", err)
+		return "", fmt.Errorf("failed to dial stun server %s: %v", stunServer, err)
+	}
+
+	stunResults, err := stunDialer(&conn)
+	if err != nil {
+		return "", fmt.Errorf("stun dialing timed out %v", err)
+	}
+	return stunResults, nil
+}
+
+func stunDialer(conn *net.Conn) (string, error) {
+	c, err := stun.NewClient(*conn)
+	if err != nil {
+		log.Errorf("Failed to open a stun socket %v", err)
+	}
+	var xorAddr stun.XORMappedAddress
+	if err = c.Do(stun.MustBuild(stun.TransactionID, stun.BindingRequest), func(res stun.Event) {
+		if res.Error != nil {
+			log.Errorf("stun request error %v", res.Error)
+			return
+		}
+		if err := xorAddr.GetFrom(res.Message); err != nil {
+			log.Errorf("stun request error %v", res)
+			if err := c.Close(); err != nil {
+				log.Errorf("stun request error %v", res)
+				return
+			}
+			return
+		}
+		log.Debugf("Stun address and port is: %s:%d", xorAddr.IP, xorAddr.Port)
+
+	}); err != nil {
+		return "", err
+	}
+	if err := c.Close(); err != nil {
+		return "", err
+	}
+	stunAddress := net.JoinHostPort(xorAddr.IP.String(), strconv.Itoa(xorAddr.Port))
+	if err != nil {
+		return "", err
+	}
+
+	return stunAddress, nil
+}

--- a/internal/client/peers.go
+++ b/internal/client/peers.go
@@ -15,16 +15,18 @@ const (
 	ZONE_PEERS = "/api/zones/%s/peers"
 )
 
-func (c *Client) CreatePeerInZone(zoneID uuid.UUID, deviceID uuid.UUID, endpointIP string, requestedIP string, childPrefix string, hubRouter bool, hubZone bool, zonePrefix string, reflexiveIP string) (models.Peer, error) {
+func (c *Client) CreatePeerInZone(zoneID uuid.UUID, deviceID uuid.UUID, endpointIP string, requestedIP string, childPrefix string, hubRouter bool, hubZone bool, zonePrefix string, reflexiveIP, endpointLocalAddress string, symmetricNat bool) (models.Peer, error) {
 	registerRequest := models.AddPeer{
-		DeviceID:      deviceID,
-		EndpointIP:    endpointIP,
-		NodeAddress:   requestedIP,
-		ChildPrefix:   childPrefix,
-		HubRouter:     hubRouter,
-		HubZone:       hubZone,
-		ZonePrefix:    zonePrefix,
-		ReflexiveIPv4: reflexiveIP,
+		DeviceID:                deviceID,
+		EndpointIP:              endpointIP,
+		NodeAddress:             requestedIP,
+		ChildPrefix:             childPrefix,
+		HubRouter:               hubRouter,
+		HubZone:                 hubZone,
+		ZonePrefix:              zonePrefix,
+		ReflexiveIPv4:           reflexiveIP,
+		EnpointLocalAddressIPv4: endpointLocalAddress,
+		SymmetricNat:            symmetricNat,
 	}
 	body, err := json.Marshal(registerRequest)
 	if err != nil {

--- a/internal/handlers/peer.go
+++ b/internal/handlers/peer.go
@@ -149,7 +149,9 @@ func (api *API) CreatePeerInZone(c *gin.Context) {
 	}
 	if found {
 		peer.ReflexiveIPv4 = request.ReflexiveIPv4
+		peer.EnpointLocalAddressIPv4 = request.EnpointLocalAddressIPv4
 		peer.EndpointIP = request.EndpointIP
+		peer.SymmetricNat = request.SymmetricNat
 
 		if request.NodeAddress != peer.NodeAddress {
 			var ip string
@@ -220,16 +222,18 @@ func (api *API) CreatePeerInZone(c *gin.Context) {
 		var allowedIPs []string
 		allowedIPs = append(allowedIPs, ipamIP)
 		peer = &models.Peer{
-			DeviceID:      device.ID,
-			ZoneID:        zone.ID,
-			EndpointIP:    request.EndpointIP,
-			AllowedIPs:    allowedIPs,
-			NodeAddress:   ipamIP,
-			ChildPrefix:   request.ChildPrefix,
-			ZonePrefix:    ipamPrefix,
-			HubZone:       hubZone,
-			HubRouter:     hubRouter,
-			ReflexiveIPv4: request.ReflexiveIPv4,
+			DeviceID:                device.ID,
+			ZoneID:                  zone.ID,
+			EndpointIP:              request.EndpointIP,
+			AllowedIPs:              allowedIPs,
+			NodeAddress:             ipamIP,
+			ChildPrefix:             request.ChildPrefix,
+			ZonePrefix:              ipamPrefix,
+			HubZone:                 hubZone,
+			HubRouter:               hubRouter,
+			ReflexiveIPv4:           request.ReflexiveIPv4,
+			EnpointLocalAddressIPv4: request.EnpointLocalAddressIPv4,
+			SymmetricNat:            request.SymmetricNat,
 		}
 		tx.Create(peer)
 		zone.Peers = append(zone.Peers, peer)

--- a/internal/models/peer.go
+++ b/internal/models/peer.go
@@ -8,27 +8,31 @@ import (
 // Peer is an association between a Device and a Zone.
 type Peer struct {
 	Base
-	DeviceID      uuid.UUID      `json:"device_id" example:"fde38e78-a4af-4f44-8f5a-d84ef1846a85"`
-	ZoneID        uuid.UUID      `json:"zone_id" example:"2b655c5b-cfdd-4550-b7f0-a36a590fc97a"`
-	EndpointIP    string         `json:"endpoint_ip" example:"10.1.1.1"`
-	AllowedIPs    pq.StringArray `json:"allowed_ips" gorm:"type:text[]"`
-	NodeAddress   string         `json:"node_address" example:"1.2.3.4"`
-	ChildPrefix   string         `json:"child_prefix" example:"172.16.42.0/24"`
-	HubRouter     bool           `json:"hub_router"`
-	HubZone       bool           `json:"hub_zone"`
-	ZonePrefix    string         `json:"zone_prefix" example:"10.1.1.0/24"`
-	ReflexiveIPv4 string         `json:"reflexive_ip4"`
+	DeviceID                uuid.UUID      `json:"device_id" example:"fde38e78-a4af-4f44-8f5a-d84ef1846a85"`
+	ZoneID                  uuid.UUID      `json:"zone_id" example:"2b655c5b-cfdd-4550-b7f0-a36a590fc97a"`
+	EndpointIP              string         `json:"endpoint_ip" example:"10.1.1.1"`
+	AllowedIPs              pq.StringArray `json:"allowed_ips" gorm:"type:text[]"`
+	NodeAddress             string         `json:"node_address" example:"1.2.3.4"`
+	ChildPrefix             string         `json:"child_prefix" example:"172.16.42.0/24"`
+	HubRouter               bool           `json:"hub_router"`
+	HubZone                 bool           `json:"hub_zone"`
+	ZonePrefix              string         `json:"zone_prefix" example:"10.1.1.0/24"`
+	ReflexiveIPv4           string         `json:"reflexive_ip4"`
+	EnpointLocalAddressIPv4 string         `json:"endpoint_local_address_ip4" example:"1.2.3.4"`
+	SymmetricNat            bool           `json:"symmetric_nat"`
 }
 
 // AddPeer are the fields required to add a new Peer
 type AddPeer struct {
-	DeviceID      uuid.UUID      `json:"device_id" example:"6a6090ad-fa47-4549-a144-02124757ab8f"`
-	EndpointIP    string         `json:"endpoint_ip" example:"10.1.1.1"`
-	AllowedIPs    pq.StringArray `json:"allowed_ips" gorm:"type:text[]"`
-	NodeAddress   string         `json:"node_address" example:"1.2.3.4"`
-	ChildPrefix   string         `json:"child_prefix" example:"172.16.42.0/24"`
-	HubRouter     bool           `json:"hub_router"`
-	HubZone       bool           `json:"hub_zone"`
-	ZonePrefix    string         `json:"zone_prefix" example:"10.1.1.0/24"`
-	ReflexiveIPv4 string         `json:"reflexive_ip4"`
+	DeviceID                uuid.UUID      `json:"device_id" example:"6a6090ad-fa47-4549-a144-02124757ab8f"`
+	EndpointIP              string         `json:"endpoint_ip" example:"10.1.1.1"`
+	AllowedIPs              pq.StringArray `json:"allowed_ips" gorm:"type:text[]"`
+	NodeAddress             string         `json:"node_address" example:"1.2.3.4"`
+	ChildPrefix             string         `json:"child_prefix" example:"172.16.42.0/24"`
+	HubRouter               bool           `json:"hub_router"`
+	HubZone                 bool           `json:"hub_zone"`
+	ZonePrefix              string         `json:"zone_prefix" example:"10.1.1.0/24"`
+	ReflexiveIPv4           string         `json:"reflexive_ip4"`
+	EnpointLocalAddressIPv4 string         `json:"endpoint_local_address_ip4" example:"1.2.3.4"`
+	SymmetricNat            bool           `json:"symmetric_nat"`
 }


### PR DESCRIPTION
- Adds a keepalive managed by the agent and disables wireguard keepalives #170
- Now supports full mesh via reflexive addresses. State is pushed from the relay node since all nodes can establish a connection there and then reconciled by the agent depending on the agent environment. #113
- Discovers symmetric NAT and builds peers to only relay and local peers.
- The agent now manages what port wireguard will listen on to help with reflexive
  NAT socket mapping and avoid overlap to be more compatible with more routers.
  The exception is the hub-router/relay node that needs to have a well-known port
  for all nodes to be able to dial into for state distribution until apex can
  do NAT whole-punching independent of a relay node.
- Adds a `--relay-only` bool switch in the case of nodes that Apex is unable to
  discern is behind a symmetric NAT. Temporary but may be useful for unforeseen
  use cases/environments.
- Adds support for child-prefixes in hub/relay zones.

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>