### PR TITLE
Makefile: remove apiserver from all target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: go-lint apex apiserver
+all: go-lint apex
 
 .PHONY: apex
 apex: dist/apex dist/apex-linux-arm dist/apex-linux-amd64 dist/apex-darwin-amd64 dist/apex-darwin-arm64 dist/apex-windows-amd64
@@ -7,6 +7,8 @@ apex: dist/apex dist/apex-linux-arm dist/apex-linux-amd64 dist/apex-darwin-amd64
 COMMON_DEPS=$(wildcard ./internal/**/*.go) go.sum go.mod
 
 APEX_DEPS=$(COMMON_DEPS) $(wildcard cmd/apex/*.go)
+
+APISERVER_DEPS=$(COMMON_DEPS) $(wildcard cmd/apiserver/*.go)
 
 TAG=$(shell git rev-parse HEAD)
 


### PR DESCRIPTION
    A recent change dropped the apiserver targets from the Makefile. The
    'all' target still had an 'apiserver' dependency, but no 'apiserver'
    target existed. We exclusively run the apiserver in a container, so we
    don't need to build it directly here.
    
    Re-add APISERVER_DEPS, as it's used as a dependency for the go-lint
    target, and that still makes sense.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
