### PR TITLE
logging: Overhaul logging to use zap

### DIFF
--- a/internal/apex/configure-hub.go
+++ b/internal/apex/configure-hub.go
@@ -211,7 +211,11 @@ func hubRouterIpTables() {
 }
 
 func (ax *Apex) addChildPrefixRoute(ChildPrefix string) {
-	if ax.os == Linux.String() && routeExists(ChildPrefix) {
+	routeExists, err := routeExists(ChildPrefix)
+	if err != nil {
+		ax.logger.Warn(err)
+	}
+	if ax.os == Linux.String() && routeExists {
 		log.Debugf("unable to add the child-prefix route [ %s ] as it already exists on this linux host", ChildPrefix)
 		return
 	}
@@ -222,7 +226,7 @@ func (ax *Apex) addChildPrefixRoute(ChildPrefix string) {
 	}
 	// add osx child prefix
 	if ax.os == Darwin.String() {
-		if err := addDarwinChildPrefixRoute(ChildPrefix); err != nil {
+		if err := addDarwinChildPrefixRoute(ax.logger, ChildPrefix); err != nil {
 			// TODO: setting to debug until the child prefix is looked up on Darwin
 			log.Debugf("error adding the child prefix route: %v", err)
 		}

--- a/internal/apex/configure-utils.go
+++ b/internal/apex/configure-utils.go
@@ -2,11 +2,11 @@ package apex
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/ini.v1"
 )
 

--- a/internal/apex/keys.go
+++ b/internal/apex/keys.go
@@ -37,7 +37,7 @@ func (ax *Apex) handleKeys() error {
 		}
 		log.Infof("No existing public/private key pair found, generating a new pair")
 		if err := ax.generateKeyPair(darwinPublicKeyFile, darwinPrivateKeyFile); err != nil {
-			log.Fatalf("Unable to locate or generate a key/pair %v", err)
+			return fmt.Errorf("Unable to locate or generate a key/pair %v", err)
 		}
 		log.Debugf("New keys were written to [ %s ] and [ %s ]", darwinPublicKeyFile, darwinPrivateKeyFile)
 		return nil
@@ -53,7 +53,7 @@ func (ax *Apex) handleKeys() error {
 		}
 		log.Infof("No existing public/private key pair found, generating a new pair")
 		if err := ax.generateKeyPair(windowsPublicKeyFile, windowsPrivateKeyFile); err != nil {
-			log.Fatalf("Unable to locate or generate a key/pair %v", err)
+			return fmt.Errorf("Unable to locate or generate a key/pair %v", err)
 		}
 		log.Debugf("New keys were written to [ %s ] and [ %s ]", windowsPublicKeyFile, windowsPrivateKeyFile)
 		return nil
@@ -69,7 +69,7 @@ func (ax *Apex) handleKeys() error {
 		}
 		log.Infof("No existing public/private key pair found, generating a new pair")
 		if err := ax.generateKeyPair(linuxPublicKeyFile, linuxPrivateKeyFile); err != nil {
-			log.Fatalf("Unable to locate or generate a key/pair %v", err)
+			return fmt.Errorf("Unable to locate or generate a key/pair %v", err)
 		}
 		log.Debugf("New keys were written to [ %s ] and [ %s ]", linuxPublicKeyFile, linuxPrivateKeyFile)
 		return nil
@@ -97,8 +97,8 @@ func (ax *Apex) generateKeyPair(publicKeyFile, privateKeyFile string) error {
 	// TODO remove this debug statement at some point
 	log.Debugf("Public Key [ %s ] Private Key [ %s ]", ax.wireguardPubKey, ax.wireguardPvtKey)
 	// write the new keys to disk
-	writeToFile(ax.wireguardPubKey, publicKeyFile, publicKeyPermissions)
-	writeToFile(ax.wireguardPvtKey, privateKeyFile, privateKeyPermissions)
+	writeToFile(ax.logger, ax.wireguardPubKey, publicKeyFile, publicKeyPermissions)
+	writeToFile(ax.logger, ax.wireguardPvtKey, privateKeyFile, privateKeyPermissions)
 
 	return nil
 }

--- a/internal/apex/utils_darwin.go
+++ b/internal/apex/utils_darwin.go
@@ -6,15 +6,16 @@ import (
 	"net"
 
 	"github.com/vishvananda/netlink"
+	"go.uber.org/zap"
 )
 
 // routeExists currently only used for darwin build purposes
-func routeExists(s string) bool {
-	return false
+func routeExists(s string) (bool, error) {
+	return false, nil
 }
 
 // discoverLinuxAddress only used for darwin build purposes
-func discoverLinuxAddress(family int) (net.IP, error) {
+func discoverLinuxAddress(logger *zap.SugaredLogger, family int) (net.IP, error) {
 	return nil, nil
 }
 

--- a/internal/apex/utils_windows.go
+++ b/internal/apex/utils_windows.go
@@ -5,15 +5,17 @@ package apex
 import (
 	"fmt"
 	"net"
+
+	"go.uber.org/zap"
 )
 
 // routeExists currently only used for windows build purposes
-func routeExists(s string) bool {
-	return false
+func routeExists(s string) (bool, error) {
+	return false, nil
 }
 
 // discoverLinuxAddress only used for windows build purposes
-func discoverLinuxAddress(family int) (net.IP, error) {
+func discoverLinuxAddress(logger *zap.SugaredLogger, family int) (net.IP, error) {
 	return nil, nil
 }
 

--- a/internal/handlers/api.go
+++ b/internal/handlers/api.go
@@ -5,17 +5,20 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/redhat-et/apex/internal/ipam"
+	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
 
 type API struct {
+	logger        *zap.SugaredLogger
 	db            *gorm.DB
 	ipam          ipam.IPAM
 	defaultZoneID uuid.UUID
 }
 
-func NewAPI(ctx context.Context, db *gorm.DB, ipam ipam.IPAM) (*API, error) {
+func NewAPI(ctx context.Context, logger *zap.SugaredLogger, db *gorm.DB, ipam ipam.IPAM) (*API, error) {
 	api := &API{
+		logger:        logger,
 		db:            db,
 		ipam:          ipam,
 		defaultZoneID: uuid.Nil,

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/redhat-et/apex/internal/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 const (
@@ -23,9 +25,10 @@ const (
 
 type HandlerTestSuite struct {
 	suite.Suite
-	ipam *http.Server
-	wg   *sync.WaitGroup
-	api  *API
+	logger *zap.SugaredLogger
+	ipam   *http.Server
+	wg     *sync.WaitGroup
+	api    *API
 }
 
 func (suite *HandlerTestSuite) SetupSuite() {
@@ -34,6 +37,7 @@ func (suite *HandlerTestSuite) SetupSuite() {
 		suite.T().Fatal(err)
 	}
 
+	suite.logger = zaptest.NewLogger(suite.T()).Sugar()
 	suite.ipam = util.NewTestIPAMServer()
 	suite.wg = &sync.WaitGroup{}
 	suite.wg.Add(1)
@@ -48,8 +52,8 @@ func (suite *HandlerTestSuite) SetupSuite() {
 		}
 	}()
 
-	ipamClient := ipam.NewIPAM(util.TestIPAMClientAddr)
-	suite.api, err = NewAPI(context.Background(), db, ipamClient)
+	ipamClient := ipam.NewIPAM(suite.logger, util.TestIPAMClientAddr)
+	suite.api, err = NewAPI(context.Background(), suite.logger, db, ipamClient)
 	if err != nil {
 		suite.T().Fatal(err)
 	}

--- a/internal/handlers/peer.go
+++ b/internal/handlers/peer.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/redhat-et/apex/internal/models"
-	log "github.com/sirupsen/logrus"
+
 	"gorm.io/gorm"
 )
 
@@ -160,7 +160,7 @@ func (api *API) CreatePeerInZone(c *gin.Context) {
 				ip, err = api.ipam.AssignSpecificNodeAddress(ctx, ipamPrefix, request.NodeAddress)
 				if err != nil {
 					tx.Rollback()
-					log.Error(err)
+					api.logger.Error(err)
 					c.JSON(http.StatusInternalServerError, models.ApiError{Error: "ipam error"})
 					return
 				}
@@ -181,13 +181,13 @@ func (api *API) CreatePeerInZone(c *gin.Context) {
 		if request.ChildPrefix != peer.ChildPrefix {
 			if err := api.ipam.AssignPrefix(ctx, request.ChildPrefix); err != nil {
 				tx.Rollback()
-				log.Error(err)
+				api.logger.Error(err)
 				c.JSON(http.StatusInternalServerError, models.ApiError{Error: "ipam error"})
 				return
 			}
 		}
 	} else {
-		log.Debugf("Public key not in the zone %s. Creating a new peer", zone.ID)
+		api.logger.Debugf("Public key not in the zone %s. Creating a new peer", zone.ID)
 		var ipamIP string
 		// If this was a static address request
 		// TODO: handle a user requesting an IP not in the IPAM prefix
@@ -196,7 +196,7 @@ func (api *API) CreatePeerInZone(c *gin.Context) {
 			ipamIP, err = api.ipam.AssignSpecificNodeAddress(ctx, ipamPrefix, request.NodeAddress)
 			if err != nil {
 				tx.Rollback()
-				log.Error(err)
+				api.logger.Error(err)
 				c.JSON(http.StatusInternalServerError, models.ApiError{Error: "ipam error"})
 				return
 			}
@@ -205,7 +205,7 @@ func (api *API) CreatePeerInZone(c *gin.Context) {
 			ipamIP, err = api.ipam.AssignFromPool(ctx, ipamPrefix)
 			if err != nil {
 				tx.Rollback()
-				log.Error(err)
+				api.logger.Error(err)
 				c.JSON(http.StatusInternalServerError, models.ApiError{Error: "ipam error"})
 				return
 			}
@@ -214,7 +214,7 @@ func (api *API) CreatePeerInZone(c *gin.Context) {
 		if request.ChildPrefix != "" {
 			if err := api.ipam.AssignPrefix(ctx, request.ChildPrefix); err != nil {
 				tx.Rollback()
-				log.Error(err)
+				api.logger.Error(err)
 				c.JSON(http.StatusInternalServerError, models.ApiError{Error: "ipam error"})
 				return
 			}
@@ -245,7 +245,7 @@ func (api *API) CreatePeerInZone(c *gin.Context) {
 
 	if err := tx.Commit(); err.Error != nil {
 		tx.Rollback()
-		log.Error(err.Error)
+		api.logger.Error(err.Error)
 		c.JSON(http.StatusInternalServerError, models.ApiError{Error: "database error"})
 		return
 	}

--- a/internal/handlers/zone.go
+++ b/internal/handlers/zone.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/redhat-et/apex/internal/models"
-	log "github.com/sirupsen/logrus"
+
 	"gorm.io/gorm"
 )
 
@@ -65,7 +65,7 @@ func (api *API) CreateZone(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, models.ApiError{Error: "unable to create zone"})
 		return
 	}
-	log.Debugf("New zone request [ %s ] and ipam [ %s ] request", newZone.Name, newZone.IpCidr)
+	api.logger.Debugf("New zone request [ %s ] and ipam [ %s ] request", newZone.Name, newZone.IpCidr)
 	c.JSON(http.StatusCreated, newZone)
 }
 
@@ -73,7 +73,7 @@ func (api *API) CreateDefaultZoneIfNotExists(ctx context.Context) error {
 	var zone models.Zone
 	res := api.db.Where("name = ?", defaultZoneName).First(&zone)
 	if errors.Is(res.Error, gorm.ErrRecordNotFound) {
-		log.Debug("Creating Default Zone")
+		api.logger.Debug("Creating Default Zone")
 		if err := api.ipam.AssignPrefix(ctx, defaultZonePrefix); err != nil {
 			return err
 		}
@@ -82,7 +82,7 @@ func (api *API) CreateDefaultZoneIfNotExists(ctx context.Context) error {
 		zone.IpCidr = defaultZonePrefix
 		api.db.Save(&zone)
 	}
-	log.Debugf("Default Zone UUID is: %s", zone.ID)
+	api.logger.Debugf("Default Zone UUID is: %s", zone.ID)
 	api.defaultZoneID = zone.ID
 	return nil
 }

--- a/internal/ipam/ipam_test.go
+++ b/internal/ipam/ipam_test.go
@@ -12,10 +12,13 @@ import (
 	"github.com/redhat-et/apex/internal/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 type IpamTestSuite struct {
 	suite.Suite
+	logger *zap.SugaredLogger
 	ipam   IPAM
 	server *http.Server
 	wg     sync.WaitGroup
@@ -23,7 +26,8 @@ type IpamTestSuite struct {
 
 func (suite *IpamTestSuite) SetupSuite() {
 	suite.server = util.NewTestIPAMServer()
-	suite.ipam = NewIPAM(util.TestIPAMClientAddr)
+	suite.logger = zaptest.NewLogger(suite.T()).Sugar()
+	suite.ipam = NewIPAM(suite.logger, util.TestIPAMClientAddr)
 	suite.wg = sync.WaitGroup{}
 	suite.wg.Add(1)
 	listener, err := net.Listen("tcp", "[::1]:9090")

--- a/internal/routers/routers.go
+++ b/internal/routers/routers.go
@@ -10,10 +10,12 @@ import (
 	"github.com/redhat-et/apex/internal/handlers"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
+	"go.uber.org/zap"
 )
 
 func NewAPIRouter(
 	ctx context.Context,
+	logger *zap.SugaredLogger,
 	api *handlers.API,
 	clientIdWeb string,
 	clientIdCli string,
@@ -36,7 +38,7 @@ func NewAPIRouter(
 
 	private := r.Group("/")
 	{
-		private.Use(ValidateJWT(verifier, clientIdWeb, clientIdCli))
+		private.Use(ValidateJWT(logger, verifier, clientIdWeb, clientIdCli))
 		private.Use(api.CreateUserIfNotExists())
 		// Zones
 		private.GET("/zones", api.ListZones)


### PR DESCRIPTION
- Doesn't pass cli.Context directly to the `apex` lib - argument parsing should be done in the main.go
- Makes a start on improving error handling in client code - don't Fatalf everywhere and prefer returning errors from functions.

Fixes: #171

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>