### PR TITLE
Adds child prefix hub zone e2e and bug fix

### DIFF
--- a/hack/kind/kind.sh
+++ b/hack/kind/kind.sh
@@ -17,12 +17,12 @@ up() {
     kubectl replace -n kube-system -f coredns.yaml
     rm coredns.yaml
     kubectl rollout restart -n kube-system deployment/coredns
-    kubectl rollout status -n kube-system deployment coredns --timeout=90s
+    kubectl rollout status -n kube-system deployment coredns --timeout=120s
 
     # Install cert-manager
     kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/cert-manager.yaml
-    kubectl rollout status -n cert-manager deploy/cert-manager --timeout=90s
-    kubectl rollout status -n cert-manager deploy/cert-manager-webhook --timeout=90s
+    kubectl rollout status -n cert-manager deploy/cert-manager --timeout=120s
+    kubectl rollout status -n cert-manager deploy/cert-manager-webhook --timeout=120s
 
     # Copy images to kind
     kind load --name apex-dev docker-image quay.io/apex/apiserver:latest
@@ -32,12 +32,12 @@ up() {
     kubectl create namespace apex
     kubectl apply -k ./deploy/overlays/dev
 
-    kubectl rollout status -n apex deployment dex --timeout=90s
-    kubectl rollout status -n apex statefulset apiserver --timeout=90s
-    kubectl rollout status -n apex statefulset ipam --timeout=90s
-    kubectl rollout status -n apex deployment backend-web --timeout=90s
-    kubectl rollout status -n apex deployment backend-cli --timeout=90s
-    kubectl rollout status -n apex deployment apiproxy --timeout=90s
+    kubectl rollout status -n apex deployment dex --timeout=120s
+    kubectl rollout status -n apex statefulset apiserver --timeout=120s
+    kubectl rollout status -n apex statefulset ipam --timeout=120s
+    kubectl rollout status -n apex deployment backend-web --timeout=120s
+    kubectl rollout status -n apex deployment backend-cli --timeout=120s
+    kubectl rollout status -n apex deployment apiproxy --timeout=120s
 
     kubectl wait --for=condition=Ready pods --all -n apex --timeout=120s
     # give k8s a little longer to come up

--- a/internal/handlers/peer.go
+++ b/internal/handlers/peer.go
@@ -148,10 +148,12 @@ func (api *API) CreatePeerInZone(c *gin.Context) {
 		}
 	}
 	if found {
+		// Update the values in the peer table
 		peer.ReflexiveIPv4 = request.ReflexiveIPv4
 		peer.EnpointLocalAddressIPv4 = request.EnpointLocalAddressIPv4
 		peer.EndpointIP = request.EndpointIP
 		peer.SymmetricNat = request.SymmetricNat
+		peer.ChildPrefix = request.ChildPrefix
 
 		if request.NodeAddress != peer.NodeAddress {
 			var ip string


### PR DESCRIPTION
- e2e for child-prefix in a hub zone.
- fixed a bug where child-prefix was not updated in the peer table if the record already existed.
- added a gather function to make it easier to debug failed e2e test nodes.
- bumped kind.sh timers for the bandwidth challenged <sad_face>

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>