### PR TITLE
selfsigned-ca: Don't replace full volumeMount list

### DIFF
--- a/deploy/components/selfsigned-ca/kustomization.yaml
+++ b/deploy/components/selfsigned-ca/kustomization.yaml
@@ -64,8 +64,8 @@ patchesJson6902:
       Name: apiserver
     patch: |-
       - op: add
-        path: /spec/template/spec/containers/1/volumeMounts
-        value: [{"name":"trust","mountPath":"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem","readOnly":true,"subPath":"tls-ca-bundle.pem"}]
+        path: /spec/template/spec/containers/1/volumeMounts/-
+        value: {"name":"trust","mountPath":"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem","readOnly":true,"subPath":"tls-ca-bundle.pem"}
       - op: add
         path: /spec/template/spec/volumes/1
         value: {"name":"trust","secret":{"secretName":"apex-ca-key-pair","optional":false,"items":[{"key":"ca.crt","path":"tls-ca-bundle.pem"}]}}


### PR DESCRIPTION
The patch for the apiserver StatefulSet replaced the entire list of volumeMounts instead of adding a volumeMount to the list. I noticed this after adding a second volumeMount in another branch.

Signed-off-by: Russell Bryant <rbryant@redhat.com>