### PR TITLE
deploy: Use exec probes for ipam

### DIFF
--- a/Containerfile.ipam
+++ b/Containerfile.ipam
@@ -1,0 +1,4 @@
+FROM ghcr.io/metal-stack/go-ipam:v1.11.3
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.14 && \
+    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+    chmod +x /bin/grpc_health_probe

--- a/deploy/apex/base/ipam/deployment.yaml
+++ b/deploy/apex/base/ipam/deployment.yaml
@@ -10,32 +10,32 @@ spec:
     spec:
       containers:
         - name: ipam
-          image: ghcr.io/metal-stack/go-ipam:v1.11.3
+          image: quay.io/apex/go-ipam:v1.11.3
           imagePullPolicy: IfNotPresent
           env:
             - name: GOIPAM_PG_HOST
               valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                   name: ipamdb-pguser-ipamdb
                   key: host
             - name: GOIPAM_PG_PORT
               valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                   name: ipamdb-pguser-ipamdb
                   key: port
             - name: GOIPAM_PG_USER
               valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                   name: ipamdb-pguser-ipamdb
                   key: user
             - name: GOIPAM_PG_PASSWORD
               valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                   name: ipamdb-pguser-ipamdb
                   key: password
             - name: GOIPAM_PG_DBNAME
               valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                   name: ipamdb-pguser-ipamdb
                   key: dbname
             - name: GOIPAM_PG_SSLMODE
@@ -51,15 +51,19 @@ spec:
               cpu: 100m
               memory: 200Mi
           readinessProbe:
-            grpc:
-              port: 9090
-              service: api.v1.IpamService
+            exec:
+              command:
+                - "/bin/grpc_health_probe"
+                - "-addr=:9090"
+                - "-service=api.v1.IpamService"
             initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
-            grpc:
-              port: 9090
-              service: api.v1.IpamService
+            exec:
+              command:
+                - "/bin/grpc_health_probe"
+                - "-addr=:9090"
+                - "-service=api.v1.IpamService"
             initialDelaySeconds: 10
             periodSeconds: 5
       restartPolicy: Always


### PR DESCRIPTION
grpc probes aren't available on the version of k8s in OpenShift

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>