### PR TITLE
deploy: Fix postgres limits for the final time

### DIFF
--- a/deploy/apex/base/apiserver/postgres.yaml
+++ b/deploy/apex/base/apiserver/postgres.yaml
@@ -15,11 +15,20 @@ spec:
             storage: 1Gi
       resources:
         limits:
-          cpu: 250m
+          cpu: 500m
           memory: 2Gi
         requests:
-          cpu: 250m
+          cpu: 500m
           memory: 2Gi
+      sidecars:
+        replicaCertCopy:
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
   backups:
     pgbackrest:
       image: quay.io/apex/crunchy-pgbackrest:ubi8-2.41-0
@@ -27,6 +36,23 @@ spec:
         # 7 Day Retention
         repo1-retention-full: "7"
         repo1-retention-full-type: time
+      sidecars:
+        pgbackrest:
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+        pgbackrestConfig:
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
       repoHost:
         resources:
           limits:

--- a/deploy/apex/base/ipam/postgres.yaml
+++ b/deploy/apex/base/ipam/postgres.yaml
@@ -15,11 +15,20 @@ spec:
             storage: 1Gi
       resources:
         limits:
-          cpu: 250m
+          cpu: 500m
           memory: 2Gi
         requests:
-          cpu: 250m
+          cpu: 500m
           memory: 2Gi
+      sidecars:
+        replicaCertCopy:
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
   backups:
     pgbackrest:
       image: quay.io/apex/crunchy-pgbackrest:ubi8-2.41-0
@@ -27,6 +36,23 @@ spec:
         # 7 Day Retention
         repo1-retention-full: "7"
         repo1-retention-full-type: time
+      sidecars:
+        pgbackrest:
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+        pgbackrestConfig:
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
       repoHost:
         resources:
           limits:


### PR DESCRIPTION
The limitranges in our OperateFirst namespace are too greedy. Each container that doesn't specify a request/limit gets a limit of 500m CPU. Since the PGO requires 4 sidecars, that was 2 CPUs PER CLUSTER - and we have 2 of them. Effectively eating all of our resourcequota.

This commit adds smaller limits to the sidecars, so each postgres cluster will need 800m CPU - 300m CPU will be used for backup jobs. In effect, we'll need:

- Postgres x 2: 1600m
- Apex Services: 700m Total: 2100m

Leaving ample headroom even including 600m for backups.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>