### PR TITLE
Add back windows support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ dist/apex-darwin-arm64: $(APEX_DEPS) | dist
 	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o $@ ./cmd/apex
 
 dist/apex-windows-amd64: $(APEX_DEPS) | dist
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o $@ ./cmd/apex
+	CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -o $@ ./cmd/apex
 
 dist/apexctl: $(APEX_DEPS) | dist
 	CGO_ENABLED=0 go build -o $@ ./cmd/apexctl

--- a/internal/apex/apex.go
+++ b/internal/apex/apex.go
@@ -26,7 +26,7 @@ const (
 	darwinIface       = "utun8"
 	WgDefaultPort     = 51820
 	wgIface           = "wg0"
-	WgWindowsConfPath = "C:/"
+	WgWindowsConfPath = "C:/apex/"
 )
 
 type Apex struct {
@@ -403,7 +403,6 @@ func checkOS(logger *zap.SugaredLogger) error {
 			return fmt.Errorf("unable to create the wireguard config directory [%s]: %v", WgDarwinConfPath, err)
 		}
 	case Windows.String():
-		logger.Fatal("Windows is temporarily unsupported")
 		logger.Debugf("[%s] operating system detected", nodeOS)
 		// ensure the windows wireguard directory exists
 		if err := CreateDirectory(WgWindowsConfPath); err != nil {
@@ -527,19 +526,21 @@ func (ax *Apex) findLocalEndpointIp() (string, error) {
 
 // binaryChecks validate the required binaries are available
 func binaryChecks() error {
+	// Windows userspace binary
 	if GetOS() == Windows.String() {
 		if !IsCommandAvailable(wgWinBinary) {
 			return fmt.Errorf("%s command not found, is wireguard installed?", wgWinBinary)
 		}
-	} else {
-		if !IsCommandAvailable(wgBinary) {
-			return fmt.Errorf("%s command not found, is wireguard installed?", wgBinary)
-		}
 	}
+	// Darwin wireguard-go userspace binary
 	if GetOS() == Darwin.String() {
 		if !IsCommandAvailable(wgGoBinary) {
 			return fmt.Errorf("%s command not found, is wireguard installed?", wgGoBinary)
 		}
+	}
+	// all OSs require the wg binary
+	if !IsCommandAvailable(wgBinary) {
+		return fmt.Errorf("%s command not found, is wireguard installed?", wgBinary)
 	}
 	return nil
 }

--- a/internal/apex/keys.go
+++ b/internal/apex/keys.go
@@ -16,8 +16,8 @@ const (
 	linuxPrivateKeyFile   = "/etc/wireguard/private.key"
 	darwinPublicKeyFile   = "/usr/local/etc/wireguard/public.key"
 	darwinPrivateKeyFile  = "/usr/local/etc/wireguard/private.key"
-	windowsPublicKeyFile  = "C:/public.key"
-	windowsPrivateKeyFile = "C:/private.key"
+	windowsPublicKeyFile  = "C:/apex/public.key"
+	windowsPrivateKeyFile = "C:/apex/private.key"
 	publicKeyPermissions  = 0644
 	privateKeyPermissions = 0600
 )

--- a/internal/apex/route.go
+++ b/internal/apex/route.go
@@ -1,30 +1,26 @@
 package apex
 
 import (
-	"fmt"
 	"net"
-
-	"go.uber.org/zap"
 )
 
 // handlePeerRoute when a new configuration is deployed, delete/add the peer allowedIPs
 func (ax *Apex) handlePeerRoute(wgPeerConfig wgPeerConfig) {
 	switch ax.os {
 	case Darwin.String():
-		// Darwin maps to a utunX address which needs to be discovered
-		netName, err := getInterfaceByIP(net.ParseIP(ax.wgLocalAddress))
+		// Darwin maps to a utunX address which needs to be discovered (currently hardcoded to utun8)
+		devName, err := getInterfaceByIP(net.ParseIP(ax.wgLocalAddress))
 		if err != nil {
 			ax.logger.Debugf("failed to find the darwin interface with the address [ %s ] %v", ax.wgLocalAddress, err)
 		}
 		// If child prefix split the two prefixes (host /32 and child prefix
 		for _, allowedIP := range wgPeerConfig.AllowedIPs {
-			_, err := RunCommand("route", "-q", "-n", "delete", "-inet", allowedIP, "-interface", netName)
+			_, err := RunCommand("route", "-q", "-n", "delete", "-inet", allowedIP, "-interface", devName)
 			if err != nil {
 				ax.logger.Debugf("no route deleted: %v", err)
 			}
-			_, err = RunCommand("route", "-q", "-n", "add", "-inet", allowedIP, "-interface", netName)
-			if err != nil {
-				ax.logger.Debugf("child prefix route add failed: %v", err)
+			if err := AddRoute(allowedIP, devName); err != nil {
+				ax.logger.Debugf("%v", err)
 			}
 		}
 
@@ -40,55 +36,36 @@ func (ax *Apex) handlePeerRoute(wgPeerConfig wgPeerConfig) {
 				}
 			}
 		}
-	}
-}
 
-// addLinuxChildPrefixRoute check if the prefix exists and add it if not
-func addLinuxChildPrefixRoute(prefix string) error {
-	routeExists, err := RouteExists(prefix)
-	if err != nil {
-		return err
-	}
-
-	if !routeExists {
-		if err := AddRoute(prefix, wgIface); err != nil {
-			return fmt.Errorf("route add failed: %v", err)
+	case Windows.String():
+		for _, allowedIP := range wgPeerConfig.AllowedIPs {
+			if err := AddRoute(allowedIP, wgIface); err != nil {
+				ax.logger.Debugf("route add failed: %v", err)
+			}
 		}
 	}
-	return nil
 }
 
-// addDarwinChildPrefixRoute todo: check if it exists
-func addDarwinChildPrefixRoute(logger *zap.SugaredLogger, prefix string) error {
-	_, err := RunCommand("route", "-q", "-n", "add", "-inet", prefix, "-interface", darwinIface)
-	if err != nil {
-		logger.Debugf("child-prefix route was added: %v", err)
+func (ax *Apex) addChildPrefixRoute(childPrefix string) {
+	var dev string
+
+	if ax.os == Darwin.String() {
+		dev = darwinIface
+	} else {
+		dev = wgIface
 	}
-	return nil
-}
 
-func (ax *Apex) addChildPrefixRoute(ChildPrefix string) {
-	routeExists, err := RouteExists(ChildPrefix)
+	routeExists, err := RouteExists(childPrefix)
 	if err != nil {
 		ax.logger.Warn(err)
 	}
 
-	if ax.os == Linux.String() && routeExists {
-		ax.logger.Debugf("unable to add the child-prefix route [ %s ] as it already exists on this linux host", ChildPrefix)
+	if routeExists {
+		ax.logger.Debugf("unable to add the child-prefix route [ %s ] as it already exists on this linux host", childPrefix)
 		return
 	}
 
-	if ax.os == Linux.String() {
-		if err := addLinuxChildPrefixRoute(ChildPrefix); err != nil {
-			ax.logger.Infof("error adding the child prefix route: %v", err)
-		}
-	}
-
-	// add osx child prefix
-	if ax.os == Darwin.String() {
-		if err := addDarwinChildPrefixRoute(ax.logger, ChildPrefix); err != nil {
-			// TODO: setting to debug until the child prefix is looked up on Darwin
-			ax.logger.Debugf("error adding the child prefix route: %v", err)
-		}
+	if err := AddRoute(childPrefix, dev); err != nil {
+		ax.logger.Infof("error adding the child prefix route: %v", err)
 	}
 }

--- a/internal/apex/utils_darwin.go
+++ b/internal/apex/utils_darwin.go
@@ -3,6 +3,7 @@
 package apex
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/vishvananda/netlink"
@@ -14,8 +15,13 @@ func RouteExists(s string) (bool, error) {
 	return false, nil
 }
 
-// AddRoute currently only used for darwin build purposes
+// AddRoute adds a route to the specified interface
 func AddRoute(prefix, dev string) error {
+	_, err := RunCommand("route", "-q", "-n", "add", "-inet", prefix, "-interface", dev)
+	if err != nil {
+		return fmt.Errorf("route add failed: %v", err)
+	}
+
 	return nil
 }
 

--- a/internal/apex/utils_windows.go
+++ b/internal/apex/utils_windows.go
@@ -14,8 +14,14 @@ func RouteExists(s string) (bool, error) {
 	return false, nil
 }
 
-// AddRoute currently only used for windows build purposes
+// AddRoute adds a windows route to the specified interface
 func AddRoute(prefix, dev string) error {
+	// TODO: replace with powershell
+	_, err := RunCommand("netsh", "int", "ipv4", "add", "route", prefix, dev)
+	if err != nil {
+		return fmt.Errorf("no windows route added: %v", err)
+	}
+
 	return nil
 }
 

--- a/internal/apex/wg-deploy.go
+++ b/internal/apex/wg-deploy.go
@@ -35,7 +35,12 @@ func (ax *Apex) DeployWireguardConfig(newPeers []models.Peer, firstTime bool) er
 		}
 
 	case Windows.String():
-		ax.logger.Infof("windows is temporarily unsupported")
+		// re-initialize the wireguard interface if it does not match it's assigned node address
+		if ax.wgLocalAddress != getIPv4Iface(wgIface).String() {
+			if err := setupWindowsIface(ax.logger, ax.wgLocalAddress, ax.wireguardPvtKey); err != nil {
+				ax.logger.Errorf("%v", err)
+			}
+		}
 	}
 
 	// add routes and tunnels for all peer candidates without checking cache since it has not been built yet

--- a/internal/apex/wg-iface.go
+++ b/internal/apex/wg-iface.go
@@ -1,0 +1,212 @@
+package apex
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// getInterfaceByIP will looks ip an interface by the IP provided
+func getInterfaceByIP(ip net.IP) (string, error) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return "", err
+	}
+
+	for _, iface := range interfaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			ifaceIP, _, err := net.ParseCIDR(addr.String())
+			if err != nil {
+				continue
+			}
+			if ifaceIP.Equal(ip) {
+				return iface.Name, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no interface was found for the ip %s", ip)
+}
+
+func setupDarwinIface(logger *zap.SugaredLogger, localAddress string) error {
+	if ifaceExists(logger, darwinIface) {
+		deleteDarwinIface(logger)
+	}
+
+	_, err := RunCommand("wireguard-go", darwinIface)
+	if err != nil {
+		logger.Errorf("failed to create the %s interface: %v\n", darwinIface, err)
+	}
+
+	_, err = RunCommand("ifconfig", darwinIface, "inet", localAddress, localAddress, "alias")
+	if err != nil {
+		logger.Errorf("failed to assign an address to the local osx interface: %v\n", err)
+	}
+
+	_, err = RunCommand("ifconfig", darwinIface, "up")
+	if err != nil {
+		logger.Errorf("failed to bring up the %s interface: %v\n", darwinIface, err)
+	}
+
+	_, err = RunCommand("wg", "set", darwinIface, "private-key", darwinPrivateKeyFile)
+	if err != nil {
+		logger.Errorf("failed to start the wireguard listener: %v\n", err)
+	}
+
+	return nil
+}
+
+// setupLinuxInterface TODO replace with netlink calls
+// this is called if this is the first run or if the local node
+// address got assigned a new address by the controller
+func (ax *Apex) setupLinuxInterface(logger *zap.SugaredLogger) {
+	// delete the wireguard ip link interface if it exists
+	if ifaceExists(logger, wgIface) {
+		_, err := RunCommand("ip", "link", "del", wgIface)
+		if err != nil {
+			logger.Debugf("failed to delete the ip link interface: %v\n", err)
+		}
+	}
+	// create the wireguard ip link interface
+	_, err := RunCommand("ip", "link", "add", wgIface, "type", "wireguard")
+	if err != nil {
+		logger.Errorf("failed to create the ip link interface: %v\n", err)
+	}
+	// start the wireguard listener on a well-known port if it is the hub-router as all
+	// nodes need to be able to reach this node for state distribution if hole punching.
+	if ax.hubRouter {
+		_, err = RunCommand("wg", "set", wgIface, "listen-port", strconv.Itoa(WgDefaultPort), "private-key", linuxPrivateKeyFile)
+		if err != nil {
+			logger.Errorf("failed to start the wireguard listener: %v\n", err)
+		}
+	} else {
+		// start the wireguard listener
+		_, err = RunCommand("wg", "set", wgIface, "listen-port", strconv.Itoa(ax.listenPort), "private-key", linuxPrivateKeyFile)
+		if err != nil {
+			logger.Errorf("failed to start the wireguard listener: %v\n", err)
+		}
+	}
+	// give the wg interface an address
+	_, err = RunCommand("ip", "address", "add", ax.wgLocalAddress, "dev", wgIface)
+	if err != nil {
+		logger.Debugf("failed to assign an address to the local linux interface, attempting to flush the iface: %v\n", err)
+		wgIP := getIPv4Iface(wgIface)
+		_, err = RunCommand("ip", "address", "del", wgIP.To4().String(), "dev", wgIface)
+		if err != nil {
+			logger.Errorf("failed to assign an address to the local linux interface: %v\n", err)
+		}
+		_, err = RunCommand("ip", "address", "add", ax.wgLocalAddress, "dev", wgIface)
+		if err != nil {
+			logger.Errorf("failed to assign an address to the local linux interface: %v\n", err)
+		}
+	}
+	// bring the wg0 interface up
+	_, err = RunCommand("ip", "link", "set", wgIface, "up")
+	if err != nil {
+		logger.Errorf("failed to bring up the wg interface: %v\n", err)
+	}
+}
+
+func setupWindowsIface(logger *zap.SugaredLogger, localAddress, privateKey string) error {
+	if err := buildWindowsWireguardIfaceConf(privateKey, localAddress); err != nil {
+		return fmt.Errorf("failed to create the windows wireguard wg0 interface file %v", err)
+	}
+
+	var wgOut string
+	var err error
+	if ifaceExists(logger, wgIface) {
+		wgOut, err = RunCommand("wireguard.exe", "/uninstalltunnelservice", wgIface)
+		if err != nil {
+			logger.Debugf("failed to down the wireguard interface (this is generally ok): %v\n", err)
+		}
+		if ifaceExists(logger, wgIface) {
+			logger.Debugf("existing windows iface %s has not been torn down yet, pausing for 1 second", wgIface)
+			time.Sleep(time.Second * 1)
+		}
+	}
+	logger.Debugf("stopped windows tunnel svc:%v\n", wgOut)
+	// sleep for one second to give the wg async exe time to tear down any existing wg0 configuration
+	wgOut, err = RunCommand("wireguard.exe", "/installtunnelservice", windowsWgConfigFile)
+	if err != nil {
+		return fmt.Errorf("failed to start the wireguard interface: %v\n", err)
+	}
+	logger.Debugf("started windows tunnel svc: %v\n", wgOut)
+	// ensure the link is created before adding peers
+	if !ifaceExists(logger, wgIface) {
+		logger.Debugf("windows iface %s has not been created yet, pausing for 1 second", wgIface)
+		time.Sleep(time.Second * 1)
+	}
+	// fatal out if the interface is not created
+	if !ifaceExists(logger, wgIface) {
+		return fmt.Errorf("failed to create the windows wireguard interface: %v\n", err)
+	}
+
+	return nil
+}
+
+// deleteDarwinIface delete the darwin userspace wireguard interface
+func deleteDarwinIface(logger *zap.SugaredLogger) {
+	tunSock := fmt.Sprintf("/var/run/wireguard/%s.sock", darwinIface)
+	_, err := RunCommand("rm", "-f", tunSock)
+	if err != nil {
+		logger.Debugf("failed to delete darwin interface: %v", err)
+	}
+	// /var/run/wireguard/wg0.name doesnt currently exist since utun8 isnt mapped to wg0 (fails silently)
+	wgName := fmt.Sprintf("/var/run/wireguard/%s.name", wgIface)
+	_, err = RunCommand("rm", "-f", wgName)
+	if err != nil {
+		logger.Debugf("failed to delete darwin interface: %v", err)
+	}
+}
+
+// ifaceExists returns true if the input matches a net interface
+func ifaceExists(logger *zap.SugaredLogger, iface string) bool {
+	_, err := net.InterfaceByName(iface)
+	if err != nil {
+		logger.Debugf("existing link not found: %s", iface)
+		return false
+	}
+
+	return true
+}
+
+// getIPv4Iface get the IP of the specified net interface
+func getIPv4Iface(ifname string) net.IP {
+	interfaces, _ := net.Interfaces()
+	for _, inter := range interfaces {
+		if inter.Name != ifname {
+			continue
+		}
+		addrs, err := inter.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			switch ip := addr.(type) {
+			case *net.IPNet:
+				if ip.IP.DefaultMask() != nil {
+					return ip.IP
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// enableForwardingIPv4 for linux nodes that are hub bouncers
+func enableForwardingIPv4(logger *zap.SugaredLogger) error {
+	cmdOut, err := RunCommand("sysctl", "-w", "net.ipv4.ip_forward=1")
+	if err != nil {
+		return fmt.Errorf("failed to enable IP Forwarding for this hub-router: %v\n", err)
+	}
+	logger.Debugf("%v", cmdOut)
+	return nil
+}

--- a/internal/apex/wg-windows.go
+++ b/internal/apex/wg-windows.go
@@ -1,0 +1,51 @@
+package apex
+
+import (
+	"fmt"
+	"os"
+	"text/template"
+)
+
+const (
+	windowsConfFilePermissions = 0644
+	windowsWgConfigFile        = "C:/apex/wg0.conf"
+)
+
+func buildWindowsWireguardIfaceConf(pvtKey, wgAddress string) error {
+	f, err := fileHandle(windowsWgConfigFile, windowsConfFilePermissions)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	t := template.Must(template.New("wgconf").Parse(windowsIfaceConfig))
+	if err := t.Execute(f, struct {
+		PrivateKey string
+		WgAddress  string
+	}{
+		PrivateKey: pvtKey,
+		WgAddress:  wgAddress,
+	}); err != nil {
+		return fmt.Errorf("failed to fill windows template %s: %w", windowsWgConfigFile, err)
+	}
+
+	return nil
+}
+
+func fileHandle(file string, permissions int) (*os.File, error) {
+	var f *os.File
+	var err error
+	f, err = os.OpenFile(file, os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(permissions))
+	if err != nil {
+		return nil, err
+	}
+
+	return f, nil
+}
+
+var windowsIfaceConfig = `
+[Interface]
+PrivateKey = {{ .PrivateKey }}
+Address = {{ .WgAddress }}
+`

--- a/internal/apex/wg.go
+++ b/internal/apex/wg.go
@@ -28,7 +28,7 @@ func (ax *Apex) handlePeerTunnel(wgPeerConfig wgPeerConfig) {
 // addPeer add a wg peer
 func (ax *Apex) addPeer(wgPeerConfig wgPeerConfig) error {
 	var wgDev string
-	if ax.os == Linux.String() {
+	if ax.os == Linux.String() || ax.os == Windows.String() {
 		wgDev = wgIface
 	}
 


### PR DESCRIPTION
- the windows wireguard utility requires a config file to bring up the wg interface. It is only there to bind the private key to the wg0 interface. This also used it to add ip to the iface. Peers are all managed with the same library across all platforms now.
- broke out interface operations into a seperate file.
Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>