### PR TITLE
Control multiple zone support with a feature flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,10 @@ OS_IMAGE?="quay.io/apex/test:fedora"
 e2e: dist/apex dist/apexctl test-images
 	go test -v --tags=integration ./integration-tests/...
 
+.PHONY: unit
+unit:
+	go test -v ./...
+
 .PHONY: images
 images:
 	docker build -f Containerfile.apiserver -t quay.io/apex/apiserver:$(TAG) .

--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,13 @@ e2e: dist/apex dist/apexctl test-images
 unit:
 	go test -v ./...
 
-.PHONY: images
-images:
-	docker build -f Containerfile.apiserver -t quay.io/apex/apiserver:$(TAG) .
+.PHONY: images image-frontend image-apiserver
+image-frontend:
 	docker build -f Containerfile.frontend -t quay.io/apex/frontend:$(TAG) .
-	docker tag quay.io/apex/apiserver:$(TAG) quay.io/apex/apiserver:latest
 	docker tag quay.io/apex/frontend:$(TAG) quay.io/apex/frontend:latest
+
+image-apiserver:
+	docker build -f Containerfile.apiserver -t quay.io/apex/apiserver:$(TAG) .
+	docker tag quay.io/apex/apiserver:$(TAG) quay.io/apex/apiserver:latest
+
+images: image-frontend image-apiserver

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/redhat-et/apex/internal/database"
+	"github.com/redhat-et/apex/internal/fflags"
 	"github.com/redhat-et/apex/internal/handlers"
 	"github.com/redhat-et/apex/internal/ipam"
 	"github.com/redhat-et/apex/internal/routers"
@@ -167,7 +168,9 @@ func main() {
 
 			ipam := ipam.NewIPAM(logger.Sugar(), cCtx.String("ipam-address"))
 
-			api, err := handlers.NewAPI(ctx, logger.Sugar(), db, ipam)
+			fflags := fflags.NewFFlags(logger.Sugar())
+
+			api, err := handlers.NewAPI(ctx, logger.Sugar(), db, ipam, fflags)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/deploy/apex/base/apiserver/deployment.yaml
+++ b/deploy/apex/base/apiserver/deployment.yaml
@@ -72,6 +72,11 @@ spec:
                 configMapKeyRef:
                   name: apiserver
                   key: APEX_TRACE_INSECURE
+            - name: APEX_FFLAG_MULTI_ZONE
+              valueFrom:
+                configMapKeyRef:
+                  name: apiserver
+                  key: APEX_FFLAG_MULTI_ZONE
           resources:
             requests:
               cpu: 100m

--- a/deploy/apex/overlays/dev/kustomization.yaml
+++ b/deploy/apex/overlays/dev/kustomization.yaml
@@ -13,6 +13,10 @@ configMapGenerator:
   files:
   - files/config.yaml
   name: dex
+- behavior: merge
+  literals:
+   - APEX_FFLAG_MULTI_ZONE=true
+  name: apiserver
 patchesJson6902:
 - target:
     kind: Ingress

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,17 +65,11 @@ To bring the cluster down again:
 
 ### HTTPS
 
-You will need to extract the CA certificate and add it to your system trust store:
+You will need to extract the CA certificate and add it to your system trust store. `kind.sh` can do
+this for you, but you must first install [`mkcert`](https://github.com/FiloSottile/mkcert).
 
 ```console
-mkdir -p .certs
-kubectl get secret -n apex apex-ca-key-pair -o json | jq -r '.data."ca.crt"' | base64 -d > .certs/rootCA.pem
-```
-
-Installation of this certificate is best left to [`mkcert`](https://github.com/FiloSottile/mkcert)
-
-```console
-CAROOT=$(pwd)/.certs mkcert -install
+./hack/kind/kind.sh cacert
 ```
 
 ## The Apex Agent

--- a/hack/kind/kind.sh
+++ b/hack/kind/kind.sh
@@ -48,6 +48,12 @@ down() {
     kind delete cluster --name apex-dev
 }
 
+cacert() {
+    mkdir -p .certs
+    kubectl get secret -n apex apex-ca-key-pair -o json | jq -r '.data."ca.crt"' | base64 -d > .certs/rootCA.pem
+    CAROOT=$(pwd)/.certs mkcert -install
+}
+
 case $1 in
     "up")
         up
@@ -55,8 +61,11 @@ case $1 in
     "down")
         down
         ;;
+    "cacert")
+        cacert
+        ;;
     *)
-        echo "command required. up or down"
+        echo "command required. up, down, or cacert"
         exit 1
         ;;
 esac

--- a/internal/fflags/fflags.go
+++ b/internal/fflags/fflags.go
@@ -1,0 +1,62 @@
+package fflags
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"go.uber.org/zap"
+)
+
+// This implementation a hack to be replaced later with a proper feature
+// flags backend. We will also need to pass in additional api user info
+// into this API so that the answer can differ depending on who is asking.
+// This is needed to allow admin-only access, or only partial rollouts of
+// features, for example.
+type FFlags struct {
+	logger *zap.SugaredLogger
+}
+
+type FFlag struct {
+	env          string
+	defaultValue bool
+}
+
+var hardCodedFlags = map[string]FFlag{
+	"multi-zone": {"APEX_FFLAG_MULTI_ZONE", false},
+}
+
+func NewFFlags(logger *zap.SugaredLogger) *FFlags {
+	return &FFlags{
+		logger: logger,
+	}
+}
+
+func (f *FFlags) getFlagValue(fflag FFlag) bool {
+	if envValue, err := strconv.ParseBool(os.Getenv(fflag.env)); err == nil {
+		return envValue
+	}
+	return fflag.defaultValue
+}
+
+// ListFlags returns a map of all currently defined feature flags and
+// whether those features are enabled (true) or not (false).
+func (f *FFlags) ListFlags() map[string]bool {
+	result := map[string]bool{}
+	for name, fflag := range hardCodedFlags {
+		result[name] = f.getFlagValue(fflag)
+	}
+	return result
+}
+
+// GetFlag returns whether the feature named by the string parameter
+// flag is enabled (true) or not (false). An error is returned if
+// the flag name is invalid.
+func (f *FFlags) GetFlag(flag string) (bool, error) {
+	fflag, ok := hardCodedFlags[flag]
+	if !ok {
+		f.logger.Errorf("Invalid feature flag name: %s", flag)
+		return false, fmt.Errorf("Invalid feature flag name: %s", flag)
+	}
+	return f.getFlagValue(fflag), nil
+}

--- a/internal/handlers/api.go
+++ b/internal/handlers/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/redhat-et/apex/internal/fflags"
 	"github.com/redhat-et/apex/internal/ipam"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -22,9 +23,10 @@ type API struct {
 	db            *gorm.DB
 	ipam          ipam.IPAM
 	defaultZoneID uuid.UUID
+	fflags        *fflags.FFlags
 }
 
-func NewAPI(parent context.Context, logger *zap.SugaredLogger, db *gorm.DB, ipam ipam.IPAM) (*API, error) {
+func NewAPI(parent context.Context, logger *zap.SugaredLogger, db *gorm.DB, ipam ipam.IPAM, fflags *fflags.FFlags) (*API, error) {
 	ctx, span := tracer.Start(parent, "NewAPI")
 	defer span.End()
 	api := &API{
@@ -32,6 +34,7 @@ func NewAPI(parent context.Context, logger *zap.SugaredLogger, db *gorm.DB, ipam
 		db:            db,
 		ipam:          ipam,
 		defaultZoneID: uuid.Nil,
+		fflags:        fflags,
 	}
 	if err := api.CreateDefaultZoneIfNotExists(ctx); err != nil {
 		return nil, err

--- a/internal/handlers/fflags.go
+++ b/internal/handlers/fflags.go
@@ -1,0 +1,48 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/redhat-et/apex/internal/models"
+)
+
+// ListFeatureFlags lists all feature flags
+// @Summary      List Feature Flags
+// @Description  Lists all feature flags
+// @Tags         FFlag
+// @Accepts		 json
+// @Produce      json
+// @Success      200  {object}
+// @Failure		 500  {object}
+// @Router       /fflags [get]
+func (api *API) ListFeatureFlags(c *gin.Context) {
+	c.JSON(http.StatusOK, api.fflags.ListFlags())
+}
+
+// GetFeatureFlag gets a feature flag by name
+// @Summary      Get Feature Flag
+// @Description  Gets a Feature Flag by name
+// @Tags         FFlag
+// @Accepts		 json
+// @Produce      json
+// @Param		 name path      string feature flag name
+// @Success      200  {object}
+// @Failure      400  {object}  models.ApiError
+// @Failure      404  {object}  models.ApiError
+// @Router       /fflags/{name} [get]
+func (api *API) GetFeatureFlag(c *gin.Context) {
+	flagName := c.Param("name")
+	if flagName == "" {
+		c.JSON(http.StatusBadRequest, models.ApiError{Error: "flag name is not valid"})
+		return
+	}
+
+	enabled, err := api.fflags.GetFlag(flagName)
+	if err != nil {
+		c.JSON(http.StatusNotFound, models.ApiError{Error: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, map[string]bool{flagName: enabled})
+}

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/redhat-et/apex/internal/fflags"
 	"github.com/redhat-et/apex/internal/ipam"
 	"github.com/redhat-et/apex/internal/util"
 	"github.com/stretchr/testify/assert"
@@ -53,7 +54,9 @@ func (suite *HandlerTestSuite) SetupSuite() {
 	}()
 
 	ipamClient := ipam.NewIPAM(suite.logger, util.TestIPAMClientAddr)
-	suite.api, err = NewAPI(context.Background(), suite.logger, db, ipamClient)
+
+	fflags := fflags.NewFFlags(suite.logger)
+	suite.api, err = NewAPI(context.Background(), suite.logger, db, ipamClient, fflags)
 	if err != nil {
 		suite.T().Fatal(err)
 	}

--- a/internal/routers/routers.go
+++ b/internal/routers/routers.go
@@ -89,6 +89,9 @@ func NewAPIRouter(
 		private.GET("/users", api.ListUsers)
 		private.PATCH("/users/:id", api.PatchUser)
 		private.DELETE("/users/:id", api.DeleteUser)
+		// Feature Flags
+		private.GET("fflags", api.ListFeatureFlags)
+		private.GET("fflags/:name", api.GetFeatureFlag)
 	}
 
 	r.GET("/api/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -28,11 +28,18 @@ const fetchJson = (url: URL, options: any = {}) => {
 
 const backend = `${window.location.protocol}//api.${window.location.host}`;
 const authProvider = goOidcAgentAuthProvider(backend);
-const dataProvider = simpleRestProvider(
+const baseDataProvider = simpleRestProvider(
   `${backend}/api`,
   fetchJson,
   'X-Total-Count',
 );
+const dataProvider = {
+  ...baseDataProvider,
+  getFlag: (name: string) => {
+    return fetchJson(new URL(`${backend}/api/fflags/${name}`))
+      .then(response => response);
+  },
+}
 
 const App = () => {
   return (

--- a/ui/src/pages/Zones.tsx
+++ b/ui/src/pages/Zones.tsx
@@ -1,3 +1,5 @@
+import { useState, useEffect, } from "react";
+import { useQuery, } from "react-query";
 import {
     Datagrid,
     List,
@@ -11,10 +13,37 @@ import {
     SimpleShowLayout,
     BooleanField,
     BooleanInput,
+    CreateButton,
+    ExportButton,
+    TopToolbar,
+    useDataProvider,
 } from 'react-admin';
 
+const ZoneCreateButton = () => {
+    const [disableCreate, setDisableCreate] = useState(false);
+    const dataProvider = useDataProvider();
+
+    useEffect(() => {
+        dataProvider.getFlag("multi-zone")
+            .then((response: any) => {
+                setDisableCreate(response.json["multi-zone"] != true)
+            });
+    });
+
+    return (
+        <CreateButton disabled={disableCreate}/>
+    );
+};
+
+const ListActions = () => (
+    <TopToolbar>
+        <ZoneCreateButton/>
+        <ExportButton/>
+    </TopToolbar>
+);
+
 export const ZoneList = () => (
-    <List>
+    <List actions={<ListActions/>}>
         <Datagrid rowClick="show" bulkActionButtons={false}>
             <TextField label="Name" source="name" />
             <TextField label="Description" source="description" />


### PR DESCRIPTION
This PR introduces the first phase of feature flags and uses a
feature flag to disable support for multiple zones (multi-zone).

The feature-flag backend is represented by the FFlags API, which, for 
now is just a simple backend with defaults that can be changed with
an environment variable. Eventually, we can replace this with one of
several other options that will allow us to do more advanced feature
controls.

Feature flags are exposed via our own API. They may be listed, or a
specific flag may be queried.

The UI consumes the API to know whether multiple zones are supported.
If they are not supported, the "Create Zone" button is disabled (or 
greyed out).

The Zone create/delete APIs also check the feature flags in the API 
server. These methods will be denied if the flag has multi-zone
support off.  Unit tests exercise the zone create/delete methods with
support on and off.

The dev deployment runs with multi-zone support on by default, but the 
prod deployment has it off.

Closes #213
Closes #214

Signed-off-by: Russell Bryant <rbryant@redhat.com>