### PR TITLE
apiserver: Fix stashing of usernames

### DIFF
--- a/internal/routers/middleware.go
+++ b/internal/routers/middleware.go
@@ -63,7 +63,13 @@ func ValidateJWT(logger *zap.SugaredLogger, verifier *oidc.IDTokenVerifier, clie
 		}
 		logger.Debugf("claims: %+v", claims)
 		c.Set(gin.AuthUserKey, claims.Subject)
-		c.Set(AuthUserName, claims.UserName)
+		if len(claims.UserName) > 0 {
+			c.Set(AuthUserName, claims.UserName)
+		} else if len(claims.FullName) > 0 {
+			c.Set(AuthUserName, claims.FullName)
+		} else {
+			logger.Debugf("Not able to determine a name for this user -- %s", claims.Subject)
+		}
 		// c.Set(AuthUserScope, claims.Scope)
 		logger.Debugf("user-id is %s", claims.Subject)
 		c.Next()


### PR DESCRIPTION
The username field is no longer showing up in the claims. That field is blank, but the FullName field has the username in it. Adjust the code to look at both, preferring username first if set.

Fixes #263

Signed-off-by: Russell Bryant <rbryant@redhat.com>