### PR TITLE
docs: Document the use of --child-prefix

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,9 @@
     - [Running the Agent for Interactive Enrollment](#running-the-agent-for-interactive-enrollment)
     - [Verifying Agent Setup](#verifying-agent-setup)
     - [Verifying Zone Connectivity](#verifying-zone-connectivity)
-  - [Cleanup](#cleanup)
+    - [Cleanup](#cleanup)
+  - [Additional Features](#additional-features)
+    - [Subnet Routers](#subnet-routers)
   - [Running the integration tests](#running-the-integration-tests)
     - [Using Docker](#using-docker)
     - [Using podman](#using-podman)
@@ -140,7 +142,7 @@ PING 10.200.0.2 (10.200.0.2) 56(84) bytes of data.
 64 bytes from 10.200.0.2: icmp_seq=1 ttl=64 time=7.63 ms
 ```
 
-## Cleanup
+### Cleanup
 
 If you want to remove the node from the network, and want to cleanup all the configuration done on the node. Fire away following commands:
 
@@ -157,6 +159,55 @@ sudo ip link del wg0
 
 ```shell
 sudo wg-quick down wg0
+```
+
+## Additional Features
+
+### Subnet Routers
+
+Typically, the Apex agent runs on every host that you intend to have connectivity to an Apex Zone. However, there may be some cases where you can't do that or don't want to. It is also possible to make a host act as a Subnet Router to provide connectivity between an Apex Zone and a local Subnet the host has access to.
+
+In the following diagram, `Host X` acts as a Subnet Router, allowing all hosts within Apex Zone A to access `192.168.100.0/24`.
+
+To configure this scenario, the `apex` agent on `Host X` must be run with the `--child-prefix` parameter.
+
+```sh
+sudo apex --child-prefix 192.168.100.0/24 [...]
+```
+
+The subnet exposed to the Apex Zone may be a physical network the host is connected to, but it can also be a network local to the host. This works well for exposing a local subnet used for containers running on that host.
+
+> **Note**
+> Subnet Routers do not perform NAT. Routes for hosts in `192.168.100.0/24` to reach Apex Zone A via `Host X` must be handled via local configuration that is appropriate for your network.
+
+```text
+┌───────────────────────────────────────────────┐
+│                                               │
+│                                               │
+│    ┌─────────┐                                │
+│    │         │                                │
+│    │ Host Y  ├────────────────────┐           │
+│    │         │                    │           │          ┌───────────────────────────┐
+│    │         │                    │           │          │                           │
+│    └────┬────┘                    │           │          │                           │
+│         │                         │           │          │                           │
+│         │                         │           │          │                           │
+│         │                      ┌──┴──────┐    │          │   Subnet Accessible by    │
+│         │                      │         │    │          │                           │
+│         │                      │ Host X  │    │          │         Host X            │
+│         │                      │         ├────┼──────────┤                           │
+│         │                      │         │    │          │                           │
+│         │                      └──┬──────┘    │          │     192.168.100.0/24      │
+│         │                         │           │          │                           │
+│    ┌────┴────┐                    │           │          │                           │
+│    │         │                    │           │          │                           │
+│    │ Host Z  │                    │           │          └───────────────────────────┘
+│    │         ├────────────────────┘           │
+│    │         │                                │
+│    └─────────┘                                │
+│                                               │
+└───────────────────────────────────────────────┘
+             Apex Zone A - 10.0.0.10/24
 ```
 
 ## Running the integration tests

--- a/docs/README.md
+++ b/docs/README.md
@@ -175,7 +175,7 @@ To configure this scenario, the `apex` agent on `Host X` must be run with the `-
 sudo apex --child-prefix 192.168.100.0/24 [...]
 ```
 
-The subnet exposed to the Apex Zone may be a physical network the host is connected to, but it can also be a network local to the host. This works well for exposing a local subnet used for containers running on that host.
+The subnet exposed to the Apex Zone may be a physical network the host is connected to, but it can also be a network local to the host. This works well for exposing a local subnet used for containers running on that host. A demo of this containers use case can be found in [scenarios/containers-on-nodes.md](scenarios/containers-on-nodes.md).
 
 > **Note**
 > Subnet Routers do not perform NAT. Routes for hosts in `192.168.100.0/24` to reach Apex Zone A via `Host X` must be handled via local configuration that is appropriate for your network.

--- a/docs/scenarios/containers-on-nodes.md
+++ b/docs/scenarios/containers-on-nodes.md
@@ -1,0 +1,93 @@
+# Mesh network between containers running on connected nodes
+
+Imagine a user wants to not only communicate between the node address each member of the mesh but also want to advertise
+some additional IP prefixes for additional services running on a node. This can be accomplished with the `--child-prefix` flag.
+Prefixes have to be unique within a zone but can overlap on separate zones.
+
+The following example allows a user to connect Docker container directly to one another without exposing a port on the node.
+These nodes could be in different data centers or CSPs. This example uses the `--child-prefix` option to advertise the private
+container networks to the mesh and enable connectivity.
+
+For simplicity, we are just using the default, built-in zone `default`.
+
+**Node1 setup:**
+
+Join node1 to the `default` zone network
+```shell
+sudo apex <CONTROLLER_URL> \
+    --child-prefix=172.24.0.0/24
+```
+
+Create the container network:
+```shell
+docker network create --driver=bridge --subnet=172.24.0.0/24 net1
+```
+
+Add the address range to the wg0 interface (required for docker only):
+```shell
+sudo iptables -I DOCKER-USER -i wg0 -d 172.24.0.0/24 -j ACCEPT
+```
+
+Start a container:
+```shell
+docker run -it --rm --network=net1 busybox bash
+```
+
+**Node2 setup**
+
+Join node2 to the `default` zone network
+
+```shell
+sudo apex <CONTROLLER_URL> \
+    --child-prefix=172.28.0.0/24
+```
+
+Setup a docker network and start a node on it:
+```shell
+docker network create --driver=bridge --subnet=172.28.0.0/24 net1
+```
+
+Add the address range to the wg0 interface (required for docker only):
+```shell
+sudo iptables -I DOCKER-USER -i wg0 -d 172.28.0.0/24 -j ACCEPT
+```
+
+Start a container:
+```shell
+docker run -it --rm --network=net1 busybox bash
+```
+
+ping the container started on Node1:
+```shell
+ping 172.28.0.x
+```
+If you don't want to create docker containers, you can create a loopback on each node's child prefix range and ping them from all nodes in the mesh like so:
+
+*On Node1:*
+```shell
+sudo ip addr add 172.24.0.10/32 dev lo
+```
+*On Node1:*
+```shell
+sudo ip addr add 172.28.0.10/32 dev lo
+```
+Ping between nodes to the loopbacks, both IPs should be reachable now because those prefixes were added to the routing tables.
+
+To go one step further, a user could then run apex on any machine, join the mesh and ping, or connect to a service, on both of the containers that were started. This could be a home developer's laptop, edge device, sensor or any other device with an IP address in the wild. That spoke connection does not require any ports to be opened to initiate the connection into the mesh.
+
+```shell
+sudo apex <CONTROLLER_URL>
+```
+Ping to prefixes on both the other nodes should be successful now.
+```
+ping 172.28.0.x
+ping 172.24.0.x
+```
+
+**NOTES:**
+
+- once you allocate a prefix, it is fixed in IPAM. We do not currently support removing the prefix.
+
+- Containers need to have unique private addresses on the docker network as exemplified above. Overlapping addresses 
+within a zone is not supported because that is a nightmare to troubleshoot, creates major fragility in SDN deployments and is 
+all around insanity. TLDR; IP address management in v4 networks is important when deploying infrastructure ¯\_(ツ)_/¯ 


### PR DESCRIPTION
Add a "Additional Feature" section to the docs, and document how the Apex agent can be instructed to act as a Subnet Router.

Signed-off-by: Russell Bryant <rbryant@redhat.com>