### PR TITLE
apex: Remove unnecessary stun option check

### DIFF
--- a/internal/apex/apex.go
+++ b/internal/apex/apex.go
@@ -500,21 +500,21 @@ func (ax *Apex) findLocalEndpointIp() (string, error) {
 	var localEndpointIP string
 	var err error
 	// Darwin network discovery
-	if !ax.stun && ax.os == Darwin.String() {
+	if ax.os == Darwin.String() {
 		localEndpointIP, err = discoverGenericIPv4(ax.logger, ax.controllerURL.Host, "443")
 		if err != nil {
 			return "", fmt.Errorf("%v", err)
 		}
 	}
 	// Windows network discovery
-	if !ax.stun && ax.os == Windows.String() {
+	if ax.os == Windows.String() {
 		localEndpointIP, err = discoverGenericIPv4(ax.logger, ax.controllerURL.Host, "443")
 		if err != nil {
 			return "", fmt.Errorf("%v", err)
 		}
 	}
 	// Linux network discovery
-	if !ax.stun && ax.os == Linux.String() {
+	if ax.os == Linux.String() {
 		linuxIP, err := discoverLinuxAddress(ax.logger, 4)
 		if err != nil {
 			return "", fmt.Errorf("%v", err)


### PR DESCRIPTION
This function is only called when either stun was not requested or if stun failed. If it fails, it seems like we'd prefer to try to find an address this way than give up without an address.

Signed-off-by: Russell Bryant <rbryant@redhat.com>