### PR TITLE
Add peer deletes to the agent

### DIFF
--- a/internal/apex/apex.go
+++ b/internal/apex/apex.go
@@ -331,6 +331,7 @@ func (ax *Apex) Reconcile(zoneID uuid.UUID, firstTime bool) error {
 			newPeers = append(newPeers, p)
 		}
 	}
+
 	if changed {
 		ax.logger.Debugf("Peers listing has changed, recalculating configuration")
 		ax.buildPeersConfig()
@@ -338,6 +339,12 @@ func (ax *Apex) Reconcile(zoneID uuid.UUID, firstTime bool) error {
 			return err
 		}
 	}
+
+	// check for any peer deletions
+	if err := ax.handlePeerDelete(peerListing); err != nil {
+		ax.logger.Error(err)
+	}
+
 	return nil
 }
 

--- a/internal/apex/utils_darwin.go
+++ b/internal/apex/utils_darwin.go
@@ -47,3 +47,13 @@ func delLink(ifaceName string) error {
 	}
 	return nil
 }
+
+// DeleteRoute deletes a darwin route
+func DeleteRoute(prefix, dev string) error {
+	_, err := RunCommand("route", "-q", "-n", "delete", "-inet", prefix, "-interface", dev)
+	if err != nil {
+		return fmt.Errorf("no route deleted: %v", err)
+	}
+
+	return nil
+}

--- a/internal/apex/utils_linux.go
+++ b/internal/apex/utils_linux.go
@@ -162,3 +162,22 @@ func delLink(ifaceName string) error {
 
 	return nil
 }
+
+// DeleteRoute deletes a netlink route
+func DeleteRoute(prefix, dev string) error {
+	link, err := netlink.LinkByName(dev)
+	if err != nil {
+		return fmt.Errorf("unable to lookup interface %s", dev)
+	}
+
+	ipNet, err := ParseIPNet(prefix)
+	if err != nil {
+		return err
+	}
+	routeSpec := netlink.Route{
+		Dst:       ipNet,
+		LinkIndex: link.Attrs().Index,
+	}
+
+	return netlink.RouteDel(&routeSpec)
+}

--- a/internal/apex/utils_windows.go
+++ b/internal/apex/utils_windows.go
@@ -48,3 +48,13 @@ func linkExists(wgIface string) bool {
 func delLink(wgIface string) (err error) {
 	return nil
 }
+
+// DeleteRoute deletes a windows route
+func DeleteRoute(prefix, dev string) error {
+	_, err := RunCommand("netsh", "int", "ipv4", "del", "route", prefix, dev)
+	if err != nil {
+		return fmt.Errorf("no route deleted: %v", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
- When a peer or device is deleted from the database, the cached peers are diffed against the latest peer listing. If the cache does not contain the peer, it is removed from all nodes in the mesh. Both the peer and routes are removed from the endpoints.

- This does not do anything on the device being deleted. That is still a tbd on how we handle that. The deleted node has no connectivity to the mesh/peers since it is removed from all of the tunnel endpoints unless it is added back to the mesh.

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>