### PR TITLE
Adds QA e2e in ec2 for operate first QA deployment

### DIFF
--- a/.github/workflows/qa-ec2.yml
+++ b/.github/workflows/qa-ec2.yml
@@ -1,0 +1,76 @@
+name: qa-ec2-e2e
+
+on: workflow_dispatch
+
+jobs:
+  deploy-ec2:
+    name: deploy-ec2-e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+    env:
+      AWS_REGION: "us-east-1"
+#      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      ANSIBLE_VAULT_PASSWORD_FILE: "vault-secret.txt"
+      ANSIBLE_PRIVATE_KEY_FILE: "apex.pem"
+      ANSIBLE_HOST_KEY_CHECKING: "false"
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
+      - name: Build
+        run: |
+          make dist/apex-linux-amd64
+
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          role-session-name: apex-ci-deploy
+          aws-region: us-east-1
+
+      - name:  Copy Agent Binary to S3
+        run: |
+          aws s3 cp ./dist/apex-linux-amd64 s3://apex-net/ec2-e2e/
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install Ansible and Dependencies
+        run: pip3.10 install boto boto3 ansible-vault ansible-core==2.13.3
+
+      - name: Install amazon.aws Ansible library
+        run: ansible-galaxy collection install amazon.aws
+
+      - name: Create Ansible Secrets
+        run: |
+          echo "${{ secrets.ANSIBLE_SSH_KEY }}" > apex.pem
+          chmod 0400 apex.pem
+          echo "${{ secrets.ANSIBLE_VAULT_PASSWORD }}" > vault-secret.txt
+          chmod 0400 vault-secret.txt
+          echo "${{ secrets.ROOT_CA }}" > ./ops/ansible/aws/rootCA.pem
+          chmod 0400 ops/ansible/aws/rootCA.pem
+          echo "${{ secrets.ANSIBLE_VARS }}" > ./ops/ansible/aws/vars.yml
+          aws s3 cp ./ops/ansible/aws/vars.yml s3://apex-net/ec2-e2e/
+
+      - name: Deploy EC2 Playbooks
+        run: |
+          ansible-playbook -vv ./ops/ansible/aws/deploy-ec2.yml \
+          -i ./ops/ansible/aws/inventory.txt \
+          --private-key apex.pem \
+          --vault-password-file vault-secret.txt
+
+      - name: Mesh Connectivity Results
+        run: cat ./ops/ansible/aws/connectivity-results.txt
+
+      - name: Terminate EC2 Instances
+        if: always()
+        run: |
+          ansible-playbook -vv ./ops/ansible/aws/terminate-instances.yml

--- a/ops/ansible/aws/ansible.cfg
+++ b/ops/ansible/aws/ansible.cfg
@@ -6,4 +6,4 @@ stdout_callback = yaml
 # defaults to the base directory in the project
 inventory = inventory.txt
 # create .pem private_key_file and provide location
-private_key_file = apex.pem
+private_key_file = ./apex.pem

--- a/ops/ansible/aws/create-zone/tasks/main.yml
+++ b/ops/ansible/aws/create-zone/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - name: Copy rootCA.pem
   copy:
-    src: ./rootCA.pem
+    src: rootCA.pem
     dest: .certs/
     mode: 0644
 
@@ -35,6 +35,16 @@
   shell: |
     sudo killall apexd 2> /dev/null
   ignore_errors: yes
+
+# Comment out the next two blocks and define "{{ controller_address }}" in vars.yml
+# if you are using a seperate api-server and not provisioning via Ansible
+#- name: Set the controller address fact
+#  set_fact:
+#    controller_address: "{{ hostvars[groups['apiServerNode'][0]]['inventory_hostname'] }}"
+
+- name: Print the API Server IP
+  debug:
+    msg: "{{ controller_address }}"
 
 - name: Delete hosts file
   become: yes
@@ -58,11 +68,11 @@
       {{ controller_address }} auth.apex.local api.apex.local apex.local
 
 # Optionally clean all remnants of a previous run (agent will do this as well)
-#- name: Delete wg0
-#  become: yes
-#  shell: |
-#    sudo ip link del wg0
-#  ignore_errors: yes
+- name: Delete wg0
+  become: yes
+  shell: |
+    sudo ip link del wg0
+  ignore_errors: yes
 
 - name: Download the Apex Agent Binary
   shell: |

--- a/ops/ansible/aws/deploy-ec2.yml
+++ b/ops/ansible/aws/deploy-ec2.yml
@@ -9,11 +9,11 @@
     - role: setup-ec2
 
 # Create a Zone
-- hosts: relayNode
-  vars_files:
-    - vars.yml
-  roles:
-    - role: create-zone
+#- hosts: relayNode
+#  vars_files:
+#    - vars.yml
+#  roles:
+#    - role: create-zone
 
 # Deploy and start the hub router
 - hosts: relayNode
@@ -28,3 +28,10 @@
     - vars.yml
   roles:
     - role: deploy-mesh
+
+# Validate nodes by running a connectivity test from the spoke node for QA e2e deployment
+- hosts:  "{{ groups['apexNodes'][0] }}"
+  vars_files:
+    - vars.yml
+  roles:
+    - role: validate-connectivity

--- a/ops/ansible/aws/deploy-mesh/tasks/main.yml
+++ b/ops/ansible/aws/deploy-mesh/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: Copy rootCA.pem
   copy:
-    src: ./rootCA.pem
+    src: rootCA.pem
     dest: .certs/
     mode: 0644
 
@@ -46,9 +46,13 @@
     sudo touch /etc/hosts
   ignore_errors: yes
 
+- name: Print the API Server IP
+  debug:
+    msg: "{{ controller_address }}"
+
 - name: Add controller host entry
   become: yes
-  ansible.builtin.blockinfile:
+  blockinfile:
     path: /etc/hosts
     block: |
       127.0.0.1 localhost

--- a/ops/ansible/aws/rootCA.pem
+++ b/ops/ansible/aws/rootCA.pem
@@ -1,1 +1,0 @@
-# replace this with rootCA.pem contents to this file

--- a/ops/ansible/aws/terminate-ec2/tasks/main.yml
+++ b/ops/ansible/aws/terminate-ec2/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # tasks file for terminate-ec2
-- name: Terminate all running ec2 instances in the region us-east-1 with the tag "{{ aws_nodetype_tag }}"
+- name: Terminate all running ec2 instances in the region us-east-1 with the nodeType tag "{{ aws_nodetype_tag }}"
   become: false
   ec2_instance:
     state: absent

--- a/ops/ansible/aws/validate-connectivity/tasks/main.yml
+++ b/ops/ansible/aws/validate-connectivity/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+# tasks file for validate-connectivity
+- name: Pause for 60 for convergence
+  pause:
+    seconds: 60
+
+- name: Summarize spoke nodes + relay node for a connectivity range
+  set_fact:
+    spoke_range_end: "{{ node_count_blue + node_count_red + node_count_green + 1 }}"
+
+- name: Get the first 3 octets of the zone prefix
+  shell: echo {{ apex_zone_prefix }} | head -c -6
+  register: ip_prefix
+
+- set_fact:
+    ip_prefix={{ ip_prefix.stdout }}
+
+- name: Debug
+  debug:
+    msg: "Running connectivity test on spoke node: {{ inventory_hostname }}"
+
+- name: Verify Connectivity from the relay node to all spokes
+  become: yes
+  shell: |
+    printf "====== Connectivity Results from Node: {{ inventory_hostname }} ======\n" > connectivity-results.txt
+    fping -s -g  {{ ip_prefix }}.1 {{ ip_prefix }}.{{ spoke_range_end }} >> connectivity-results.txt 2>&1
+  ignore_errors: yes
+
+- name: Copy connectivity results back to the runner
+  ansible.builtin.fetch:
+    src: /home/{{ ansible_user }}/connectivity-results.txt
+    dest: ./
+    flat: true

--- a/ops/ansible/aws/vars.yml
+++ b/ops/ansible/aws/vars.yml
@@ -3,7 +3,7 @@ aws_region: us-east-1                 # AWS region
 aws_image_id: ami-052efd3df9dad4825   # Ubuntu 22.04 (this can be changed to most any Linux distro)
 aws_key_name: <YOUR_EC2_KEY_NAME>     # the key pair on your aws account to use
 aws_instance_type: t2.micro           # t2.micro is free tier eligable, but you can use any type to scale up, more examples [t2.large, t2.xlarge, t2.2xlarge]
-aws_nodetype_tag: apex-demo-nodes     # Unique tag identifier for ec2 instances
+aws_nodetype_tag: apex-e2e            # Unique tag identifier for ec2 instances
 ansible_user: ubuntu                  # this is the default user ID for your AMI image. Example, AWS AMI is ec2-user etc
 security_group_description: "Apex Testing and Demos"
 inventory_location: inventory.txt     # leaving this as is will use the inventory.txt file in the base directory
@@ -16,17 +16,17 @@ aws_subnet_blue: subnet-c8db48e9           # VPC subnet id from your aws account
 
 ### Red VPC Details ###
 secgroup_name_red: ApexRed
-secgroup_id_red: sg-025e719f27ac1af10    # the security group name can be an existing group or else it will be created by the playbook
+secgroup_id_red: sg-025e719f27ac1af10      # the security group name can be an existing group or else it will be created by the playbook
 node_count_red: 2                          # the number of cluster nodes you want to deploy
 vpc_id_red: vpc-0110617328fb491f8          # VPC id from your aws account
-aws_subnet_red: subnet-08c72986ee9792e8b # VPC subnet id from your aws account
+aws_subnet_red: subnet-08c72986ee9792e8b   # VPC subnet id from your aws account
 
 ### Green VPC Details ###
 secgroup_name_green: ApexGreen
-secgroup_id_green: sg-039d3246c3daabac3   # the security group name can be an existing group or else it will be created by the playbook
+secgroup_id_green: sg-039d3246c3daabac3     # the security group name can be an existing group or else it will be created by the playbook
 node_count_green: 2                         # the number of cluster nodes you want to deploy
 vpc_id_green: vpc-0566e09aa71f553c1         # VPC id from your aws account
-aws_subnet_green: subnet-0f8a1403fde2af94e           # VPC subnet id from your aws account
+aws_subnet_green: subnet-0f8a1403fde2af94e  # VPC subnet id from your aws account
 
 ### Controller Section (values are there for example, replace with your environment) ###
 controller_address: <CONTROLLER_ADDRESS>


### PR DESCRIPTION
- Adds vars to repo secrets.
- Ansible vars are encrypted and stored in GH secrets. These vars contain the deployment details (node count, VPCs, etc)
- Once nodes are deployed, connectivity is verified from the relay node to all of the spoke nodes. Output is saved and displayed in the action output. This will be tweeked and further tests will be added once this is up and functional via webhooks from operate first.

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>