### PR TITLE
Makefile: Check prereqs before running e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,23 @@ test-images:
 	docker build -f Containerfile.test -t quay.io/apex/test:fedora --target fedora .
 	docker build -f Containerfile.test -t quay.io/apex/test:ubuntu --target ubuntu .
 
-.PHONY: e2e
-e2e: dist/apex dist/apexctl test-images
+.PHONY: e2e e2eprereqs
+e2eprereqs:
+	@if [ -z "$(shell which kind)" ]; then \
+		echo "Please install kind and then start the kind dev environment." ; \
+		echo "https://kind.sigs.k8s.io/" ; \
+		echo "  $$ hack/kind/kind.sh up" ; \
+		echo "  $$ hack/kind/kind.sh cacert" ; \
+		exit 1 ; \
+	fi
+	@if [ -z "$(findstring apex-dev,$(shell kind get clusters))" ]; then \
+		echo "Please start the kind dev environment." ; \
+		echo "  $$ hack/kind/kind.sh up" ; \
+		echo "  $$ hack/kind/kind.sh cacert" ; \
+		exit 1 ; \
+	fi
+
+e2e: e2eprereqs dist/apex dist/apexctl test-images
 	go test -v --tags=integration ./integration-tests/...
 
 .PHONY: unit

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@
   - [Additional Features](#additional-features)
     - [Subnet Routers](#subnet-routers)
   - [Running the integration tests](#running-the-integration-tests)
+    - [Prerequisites](#prerequisites)
     - [Using Docker](#using-docker)
     - [Using podman](#using-podman)
 
@@ -37,7 +38,7 @@ The development Apex stack requires 3 hostnames to be reachable:
 - `api.apex.local` - for the backend apis
 - `apex.local` - for the frontend
 
-To add these on your own machine:
+To add these on your own machine for a local development environment:
 
 ```console
 echo "127.0.0.1 auth.apex.local api.apex.local apex.local" | sudo tee -a /etc/hosts
@@ -186,6 +187,10 @@ graph
 ```
 
 ## Running the integration tests
+
+### Prerequisites
+
+Prior to running the integration tests, you must start the kind-based development environment. See the [Run on Kubernetes](#run-on-kubernetes) section for further details.
 
 ### Using Docker
 


### PR DESCRIPTION
When running "make e2e", make sure that kind is installed and that the "apex-dev" kind cluster is running.

Signed-off-by: Russell Bryant <rbryant@redhat.com>