### PR TITLE
kind.sh: Only run on Linux

### DIFF
--- a/hack/kind/kind.sh
+++ b/hack/kind/kind.sh
@@ -38,6 +38,11 @@ up() {
         exit 1
     fi
 
+    if [ "$(command uname -s)" != "Linux" ]; then
+        error_message "$(command basename $0) is only known to work on Linux (not $(command uname -s))"
+        exit 1
+    fi
+
     kind create cluster --config ./deploy/kind.yaml
     kubectl cluster-info --context kind-apex-dev
 


### PR DESCRIPTION
This appears to break on Mac right now, so just block it until someone has a chance to figure it out.

Signed-off-by: Russell Bryant <rbryant@redhat.com>