### PR TITLE
Use gomigrate to manage the DB migrations.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/docker/docker v20.10.22+incompatible
 	github.com/gin-contrib/zap v0.1.0
 	github.com/gin-gonic/gin v1.8.2
+	github.com/go-gormigrate/gormigrate/v2 v2.0.2
 	github.com/google/uuid v1.3.0
 	github.com/metal-stack/go-ipam v1.11.4
 	github.com/pion/stun v0.3.5
@@ -128,7 +129,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/montanaflynn/stats v0.6.6 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ugorji/go/codec v1.2.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,7 @@ github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/denisenkom/go-mssqldb v0.12.0 h1:VtrkII767ttSPNRfFekePK3sctr+joXgO58stqQbtUA=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
@@ -144,6 +145,8 @@ github.com/gin-gonic/gin v1.8.2/go.mod h1:qw5AYuDrzRTnhvusDsrov+fDIxp9Dleuu12h8n
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-gormigrate/gormigrate/v2 v2.0.2 h1:YV4Lc5yMQX8ahVW0ENPq6sPhrhdkGukc6fPRYmZ1R6Y=
+github.com/go-gormigrate/gormigrate/v2 v2.0.2/go.mod h1:vld36QpBTfTzLealsHsmQQJK5lSwJt6wiORv+oFX8/I=
 github.com/go-jose/go-jose/v3 v3.0.0 h1:s6rrhirfEP/CGIoc6p+PZAeogN2SxKav6Wp7+dyMWVo=
 github.com/go-jose/go-jose/v3 v3.0.0/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -192,6 +195,8 @@ github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
+github.com/golang-sql/sqlexp v0.0.0-20170517235910-f1bb20e5a188 h1:+eHOFJl1BaXrQxKX+T06f78590z4qA2ZzBTqahsKSE4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
@@ -287,6 +292,7 @@ github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jmoiron/sqlx v1.3.5 h1:vFFPA71p1o5gAeqtEAwLU4dnX2napprKtHr7PYIcN3g=
 github.com/jmoiron/sqlx v1.3.5/go.mod h1:nRVWtLre0KfCLJvgxzCsLVMogSvQ1zNJtpYr2Ccp0mQ=
+github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/josharian/native v1.0.0 h1:Ts/E8zCSEsG17dUqv7joXJFybuMLjQfWE04tsBODTxk=
@@ -947,10 +953,12 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gorm.io/driver/mysql v1.3.3 h1:jXG9ANrwBc4+bMvBcSl8zCfPBaVoPyBEBshA8dA93X8=
 gorm.io/driver/postgres v1.4.6 h1:1FPESNXqIKG5JmraaH2bfCVlMQ7paLoCreFxDtqzwdc=
 gorm.io/driver/postgres v1.4.6/go.mod h1:UJChCNLFKeBqQRE+HrkFUbKbq9idPXmTOk2u4Wok8S4=
 gorm.io/driver/sqlite v1.4.4 h1:gIufGoR0dQzjkyqDyYSCvsYR6fba1Gw5YKDqKeChxFc=
 gorm.io/driver/sqlite v1.4.4/go.mod h1:0Aq3iPO+v9ZKbcdiz8gLWRw5VOPcBOPUQJFLq5e2ecI=
+gorm.io/driver/sqlserver v1.3.2 h1:yYt8f/xdAKLY7lCCyXxIUEgZ/WsURos3dHrx8MKFGAk=
 gorm.io/gorm v1.24.0/go.mod h1:DVrVomtaYTbqs7gB/x2uVvqnXzv0nqjB396B8cG4dBA=
 gorm.io/gorm v1.24.2/go.mod h1:DVrVomtaYTbqs7gB/x2uVvqnXzv0nqjB396B8cG4dBA=
 gorm.io/gorm v1.24.3 h1:WL2ifUmzR/SLp85CSURAfybcHnGZ+yLSGSxgYXlFBHg=

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -3,9 +3,7 @@ package database
 import (
 	"context"
 	"fmt"
-
 	"github.com/cenkalti/backoff/v4"
-	"github.com/redhat-et/apex/internal/models"
 	"github.com/uptrace/opentelemetry-go-extra/otelgorm"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -53,27 +51,5 @@ func NewDatabase(
 	if err := db.Use(otelgorm.NewPlugin()); err != nil {
 		return nil, err
 	}
-	if err := Migrate(ctx, db); err != nil {
-		return nil, err
-	}
 	return db, nil
-}
-
-func Migrate(ctx context.Context, db *gorm.DB) error {
-	_, span := tracer.Start(ctx, "Migrate")
-	defer span.End()
-	// Migrate the schema
-	if err := db.AutoMigrate(&models.User{}); err != nil {
-		return err
-	}
-	if err := db.AutoMigrate(&models.Zone{}); err != nil {
-		return err
-	}
-	if err := db.AutoMigrate(&models.Peer{}); err != nil {
-		return err
-	}
-	if err := db.AutoMigrate(&models.Device{}); err != nil {
-		return err
-	}
-	return nil
 }

--- a/internal/database/migrations/20230113-0000.go
+++ b/internal/database/migrations/20230113-0000.go
@@ -1,0 +1,97 @@
+package migrations
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"time"
+)
+
+func addApexTables() *gormigrate.Migration {
+
+	// Migrations rules:
+	//
+	//  1. IDs are numerical timestamps that must sort ascending.
+	//     Use YYYYMMDD-HHMM w/ 24 hour time for format
+	//     Example: August 21 2018 at 2:54pm would be 20180821-1454.
+	//
+	//  2. Include models inline with migrations to see the evolution of the object over time.
+	//     Using our internal type models directly in the first migration would fail in future clean
+	//     installations.
+	//
+	//  3. Migrations must be backwards compatible. There are no new required fields allowed.
+	//
+	// 4. Create one function in a separate file that returns your Migration.
+	migrationId := "20230113-0000"
+
+	type Base struct {
+		ID        uuid.UUID  `gorm:"type:uuid;primary_key;" json:"id" example:"aa22666c-0f57-45cb-a449-16efecc04f2e"`
+		CreatedAt time.Time  `json:"-"`
+		UpdatedAt time.Time  `json:"-"`
+		DeletedAt *time.Time `sql:"index" json:"-"`
+	}
+
+	type Peer struct {
+		Base
+		DeviceID                 uuid.UUID      `json:"device_id" example:"fde38e78-a4af-4f44-8f5a-d84ef1846a85"`
+		ZoneID                   uuid.UUID      `json:"zone_id" example:"2b655c5b-cfdd-4550-b7f0-a36a590fc97a"`
+		EndpointIP               string         `json:"endpoint_ip" example:"10.1.1.1"`
+		AllowedIPs               pq.StringArray `json:"allowed_ips" gorm:"type:text[]"`
+		NodeAddress              string         `json:"node_address" example:"1.2.3.4"`
+		ChildPrefix              string         `json:"child_prefix" example:"172.16.42.0/24"`
+		HubRouter                bool           `json:"hub_router"`
+		HubZone                  bool           `json:"hub_zone"`
+		ZonePrefix               string         `json:"zone_prefix" example:"10.1.1.0/24"`
+		ReflexiveIPv4            string         `json:"reflexive_ip4"`
+		EndpointLocalAddressIPv4 string         `json:"endpoint_local_address_ip4" example:"1.2.3.4"`
+		SymmetricNat             bool           `json:"symmetric_nat"`
+	}
+
+	type Zone struct {
+		Base
+		Peers       []*Peer     `json:"-"`
+		PeerList    []uuid.UUID `gorm:"-" json:"peers" example:"4902c991-3dd1-49a6-9f26-d82496c80aff"`
+		Name        string      `gorm:"" json:"name" example:"zone-red"`
+		Description string      `json:"description" example:"The Red Zone"`
+		IpCidr      string      `json:"cidr" example:"172.16.42.0/24"`
+		HubZone     bool        `json:"hub_zone"`
+	}
+
+	type Device struct {
+		Base
+		UserID    string      `json:"user_id" example:"694aa002-5d19-495e-980b-3d8fd508ea10"`
+		PublicKey string      `gorm:"" json:"public_key"`
+		Peers     []*Peer     `json:"-"`
+		PeerList  []uuid.UUID `gorm:"-" json:"peers" example:"97d5214a-8c51-4772-b492-53de034740c5"`
+		Hostname  string      `json:"hostname" example:"myhost"`
+	}
+
+	type User struct {
+		// Since the ID comes from the IDP, we have no control over the format...
+		ID         string      `gorm:"primary_key;" json:"id" example:"aa22666c-0f57-45cb-a449-16efecc04f2e"`
+		CreatedAt  time.Time   `json:"-"`
+		UpdatedAt  time.Time   `json:"-"`
+		DeletedAt  *time.Time  `sql:"index" json:"-"`
+		Devices    []*Device   `json:"-"`
+		DeviceList []uuid.UUID `gorm:"-" json:"devices" example:"4902c991-3dd1-49a6-9f26-d82496c80aff"`
+		ZoneID     uuid.UUID   `json:"zone_id" example:"94deb404-c4eb-4097-b59d-76b024ff7867"`
+		UserName   string      `json:"username" example:"admin"`
+	}
+
+	return CreateMigrationFromActions(migrationId,
+		CreateTableAction(&User{}),
+		CreateTableAction(&Peer{}),
+		CreateTableAction(&Zone{}),
+		// manually crete the unique indexes for now so that migrations work on cockroach see issue:
+		// https://github.com/go-gorm/gorm/issues/5752
+		ExecAction(
+			`CREATE UNIQUE INDEX IF NOT EXISTS "idx_zones_name" ON "zones" ("name")`,
+			`DROP INDEX zones@idx_zones_name`,
+		),
+		CreateTableAction(&Device{}),
+		ExecAction(
+			`CREATE UNIQUE INDEX IF NOT EXISTS "idx_devices_public_key" ON "devices" ("public_key")`,
+			`DROP INDEX devices@idx_devices_public_key`,
+		),
+	)
+}

--- a/internal/database/migrations/migrations.go
+++ b/internal/database/migrations/migrations.go
@@ -1,0 +1,361 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+	"gorm.io/gorm"
+	"runtime"
+)
+
+var tracer trace.Tracer
+
+func init() {
+	tracer = otel.Tracer("github.com/redhat-et/apex/internal/database")
+}
+
+type Migrations struct {
+	Migrations  []*gormigrate.Migration
+	GormOptions *gormigrate.Options
+}
+
+func (m *Migrations) Migrate(ctx context.Context, db *gorm.DB) error {
+	_, span := tracer.Start(ctx, "Migrate")
+	defer span.End()
+	db = db.Debug()
+	return gormigrate.New(db, m.GormOptions, m.Migrations).Migrate()
+}
+
+// Migrating to a specific migration will not seed the database, seeds are up to date with the latest
+// schema based on the most recent migration
+// This should be for testing purposes mainly
+func (m *Migrations) MigrateTo(ctx context.Context, db *gorm.DB, migrationID string) error {
+	_, span := tracer.Start(ctx, "MigrateTo")
+	defer span.End()
+
+	gm := gormigrate.New(db, m.GormOptions, m.Migrations)
+	return gm.MigrateTo(migrationID)
+}
+
+func (m *Migrations) RollbackLast(ctx context.Context, db *gorm.DB) error {
+	_, span := tracer.Start(ctx, "RollbackLast")
+	defer span.End()
+
+	gm := gormigrate.New(db, m.GormOptions, m.Migrations)
+	if err := gm.RollbackLast(); err != nil {
+		return err
+	}
+	return m.deleteMigrationTableIfEmpty(db)
+}
+
+func (m *Migrations) RollbackTo(ctx context.Context, db *gorm.DB, migrationID string) error {
+	_, span := tracer.Start(ctx, "RollbackTo")
+	defer span.End()
+
+	gm := gormigrate.New(db, m.GormOptions, m.Migrations)
+	return gm.RollbackTo(migrationID)
+}
+
+// RollbackAll rolls back all migrations..
+func (m *Migrations) RollbackAll(ctx context.Context, db *gorm.DB) error {
+	_, span := tracer.Start(ctx, "RollbackAll")
+	defer span.End()
+
+	gm := gormigrate.New(db, m.GormOptions, m.Migrations)
+	type Result struct {
+		ID string
+	}
+	sql := fmt.Sprintf("SELECT %s AS id FROM %s", m.GormOptions.IDColumnName, m.GormOptions.TableName)
+	for {
+		var result Result
+		err := db.Raw(sql).Scan(&result).Error
+		if err != nil || result.ID == "" {
+			break
+		}
+		if err := gm.RollbackLast(); err != nil {
+			return err
+		}
+	}
+	return m.deleteMigrationTableIfEmpty(db)
+}
+
+func (m *Migrations) deleteMigrationTableIfEmpty(db *gorm.DB) error {
+	if !db.Migrator().HasTable(m.GormOptions.TableName) {
+		return nil
+	}
+	result, err := m.CountMigrationsApplied(db)
+	if err != nil {
+		return err
+	}
+	if result == 0 {
+		if err := db.Migrator().DropTable(m.GormOptions.TableName); err != nil {
+			return fmt.Errorf("could not drop migration table: %w", err)
+		}
+	}
+	return nil
+}
+
+func (m *Migrations) CountMigrationsApplied(db *gorm.DB) (int, error) {
+	if !db.Migrator().HasTable(m.GormOptions.TableName) {
+		return 0, nil
+	}
+	sql := fmt.Sprintf("SELECT count(%s) AS id FROM %s", m.GormOptions.IDColumnName, m.GormOptions.TableName)
+	var count int
+	if err := db.Raw(sql).Scan(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+type MigrationAction func(tx *gorm.DB, apply bool) error
+
+func CreateTableAction(table interface{}) MigrationAction {
+	caller := ""
+	if _, file, no, ok := runtime.Caller(1); ok {
+		caller = fmt.Sprintf("[ %s:%d ]", file, no)
+	}
+	return func(tx *gorm.DB, apply bool) error {
+		if apply {
+			err := tx.AutoMigrate(table)
+			if err != nil {
+				return errors.Wrap(err, caller)
+			}
+		} else {
+			err := tx.Migrator().DropTable(table)
+			if err != nil {
+				return errors.Wrap(err, caller)
+			}
+		}
+		return nil
+	}
+}
+
+func DropTableAction(table interface{}) MigrationAction {
+	caller := ""
+	if _, file, no, ok := runtime.Caller(1); ok {
+		caller = fmt.Sprintf("[ %s:%d ]", file, no)
+	}
+	return func(tx *gorm.DB, apply bool) error {
+		if apply {
+			err := tx.Migrator().DropTable(table)
+			if err != nil {
+				return errors.Wrap(err, caller)
+			}
+		} else {
+			err := tx.AutoMigrate(table)
+			if err != nil {
+				return errors.Wrap(err, caller)
+			}
+		}
+		return nil
+	}
+}
+
+func AddTableColumnsAction(table interface{}) MigrationAction {
+	caller := ""
+	if _, file, no, ok := runtime.Caller(1); ok {
+		caller = fmt.Sprintf("[ %s:%d ]", file, no)
+	}
+	return func(tx *gorm.DB, apply bool) error {
+		if apply {
+			stmt := &gorm.Statement{DB: tx}
+			if err := stmt.Parse(table); err != nil {
+				return errors.Wrap(err, caller)
+			}
+			for _, field := range stmt.Schema.FieldsByDBName {
+				if err := tx.Migrator().AddColumn(table, field.DBName); err != nil {
+					return errors.Wrap(err, caller)
+				}
+			}
+		} else {
+			stmt := &gorm.Statement{DB: tx}
+			if err := stmt.Parse(table); err != nil {
+				return errors.Wrap(err, caller)
+			}
+			for _, field := range stmt.Schema.FieldsByDBName {
+				if err := tx.Migrator().DropColumn(table, field.DBName); err != nil {
+					return errors.Wrap(err, caller)
+				}
+			}
+		}
+		return nil
+
+	}
+}
+
+func AddTableColumnAction(table interface{}, columnName string) MigrationAction {
+	caller := ""
+	if _, file, no, ok := runtime.Caller(1); ok {
+		caller = fmt.Sprintf("[ %s:%d ]", file, no)
+	}
+	return func(tx *gorm.DB, apply bool) error {
+		if apply {
+			if err := tx.Migrator().AddColumn(table, columnName); err != nil {
+				return errors.Wrap(err, caller)
+			}
+		} else {
+			if err := tx.Migrator().DropColumn(table, columnName); err != nil {
+				return errors.Wrap(err, caller)
+			}
+		}
+		return nil
+
+	}
+}
+
+func DropTableColumnsAction(table interface{}, tableName ...string) MigrationAction {
+	caller := ""
+	if _, file, no, ok := runtime.Caller(1); ok {
+		caller = fmt.Sprintf("[ %s:%d ]", file, no)
+	}
+	return func(tx *gorm.DB, apply bool) error {
+		if apply {
+			stmt := &gorm.Statement{DB: tx}
+			if err := stmt.Parse(table); err != nil {
+				return errors.Wrap(err, caller)
+			}
+			if len(tableName) > 0 {
+				stmt.Schema.Table = tableName[0]
+			}
+			for _, field := range stmt.Schema.FieldsByDBName {
+				if err := tx.Migrator().DropColumn(table, field.DBName); err != nil {
+					return errors.Wrap(err, caller)
+				}
+			}
+		} else {
+			stmt := &gorm.Statement{DB: tx}
+			if err := stmt.Parse(table); err != nil {
+				return errors.Wrap(err, caller)
+			}
+			if len(tableName) > 0 {
+				stmt.Schema.Table = tableName[0]
+			}
+			for _, field := range stmt.Schema.FieldsByDBName {
+				if err := tx.Migrator().AddColumn(table, field.DBName); err != nil {
+					return errors.Wrap(err, caller)
+				}
+			}
+		}
+		return nil
+
+	}
+}
+
+func DropTableColumnAction(table interface{}, columnName string) MigrationAction {
+	caller := ""
+	if _, file, no, ok := runtime.Caller(1); ok {
+		caller = fmt.Sprintf("[ %s:%d ]", file, no)
+	}
+	return func(tx *gorm.DB, apply bool) error {
+		if apply {
+			if err := tx.Migrator().DropColumn(table, columnName); err != nil {
+				return errors.Wrap(err, caller)
+			}
+		} else {
+			if err := tx.Migrator().AddColumn(table, columnName); err != nil {
+				return errors.Wrap(err, caller)
+			}
+		}
+		return nil
+
+	}
+}
+
+func RenameTableColumnAction(table interface{}, oldFieldName string, newFieldName string) MigrationAction {
+	caller := ""
+	if _, file, no, ok := runtime.Caller(1); ok {
+		caller = fmt.Sprintf("[ %s:%d ]", file, no)
+	}
+	return func(tx *gorm.DB, apply bool) error {
+		if apply {
+			if err := tx.Migrator().RenameColumn(table, oldFieldName, newFieldName); err != nil {
+				return errors.Wrap(err, caller)
+			}
+		} else {
+			if err := tx.Migrator().RenameColumn(table, newFieldName, oldFieldName); err != nil {
+				return errors.Wrap(err, caller)
+			}
+		}
+		return nil
+
+	}
+}
+
+func ExecAction(applySql string, unapplySql string) MigrationAction {
+	caller := ""
+	if _, file, no, ok := runtime.Caller(1); ok {
+		caller = fmt.Sprintf("[ %s:%d ]", file, no)
+	}
+
+	return func(tx *gorm.DB, apply bool) error {
+		if apply {
+			if applySql != "" {
+				err := tx.Exec(applySql).Error
+				if err != nil {
+					return errors.Wrap(err, caller)
+				}
+			}
+		} else {
+			if unapplySql != "" {
+				err := tx.Exec(unapplySql).Error
+				if err != nil {
+					return errors.Wrap(err, caller)
+				}
+			}
+		}
+		return nil
+
+	}
+}
+
+func FuncAction(applyFunc func(*gorm.DB) error, unapplyFunc func(*gorm.DB) error) MigrationAction {
+	caller := ""
+	if _, file, no, ok := runtime.Caller(1); ok {
+		caller = fmt.Sprintf("[ %s:%d ]", file, no)
+	}
+
+	return func(tx *gorm.DB, apply bool) error {
+		if apply {
+			err := applyFunc(tx)
+			if err != nil {
+				return errors.Wrap(err, caller)
+			}
+		} else {
+			err := unapplyFunc(tx)
+			if err != nil {
+				return errors.Wrap(err, caller)
+			}
+		}
+		return nil
+
+	}
+}
+
+func CreateMigrationFromActions(id string, actions ...MigrationAction) *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: id,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.Debug()
+			for _, action := range actions {
+				err := action(tx, true)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.Debug()
+			for i := len(actions) - 1; i >= 0; i-- {
+				err := actions[i](tx, false)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+}

--- a/internal/database/migrations/new.go
+++ b/internal/database/migrations/new.go
@@ -1,0 +1,21 @@
+package migrations
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+)
+
+// gormigrate is a wrapper for gorm's migration functions that adds schema versioning and rollback capabilities.
+// For help writing migration steps, see the gorm documentation on migrations: https://gorm.io/docs/migration.html
+func New() *Migrations {
+	return &Migrations{
+		GormOptions: &gormigrate.Options{
+			TableName:      "apiserver_migrations",
+			IDColumnName:   "id",
+			IDColumnSize:   40,
+			UseTransaction: false,
+		},
+		Migrations: []*gormigrate.Migration{
+			addApexTables(),
+		},
+	}
+}

--- a/internal/util/utils.go
+++ b/internal/util/utils.go
@@ -2,13 +2,13 @@ package util
 
 import (
 	"context"
+	"github.com/redhat-et/apex/internal/database/migrations"
 	"net/http"
 	"time"
 
 	goipam "github.com/metal-stack/go-ipam"
 	"github.com/metal-stack/go-ipam/api/v1/apiv1connect"
 	"github.com/metal-stack/go-ipam/pkg/service"
-	"github.com/redhat-et/apex/internal/database"
 	"go.uber.org/zap"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
@@ -25,7 +25,8 @@ func NewTestDatabase() (*gorm.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := database.Migrate(context.Background(), db); err != nil {
+
+	if err := migrations.New().Migrate(context.Background(), db); err != nil {
 		return nil, err
 	}
 	return db, nil


### PR DESCRIPTION
This allows us to apply or rollback migrations.  This change also manually creates the unique indexes so that migrations work against cockroach.