### PR TITLE
Fix for "Installer fails on EC2 Ubuntu AMI"

### DIFF
--- a/hack/apex-installer.sh
+++ b/hack/apex-installer.sh
@@ -96,6 +96,7 @@ EOF
         if ! [ -x "$(command -v wg)" ]; then
             info_message "Wireguard is not installed. Installing WireGuard..."
             if [ "$linuxDistro" == "Ubuntu" ]; then
+                sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
                 sudo DEBIAN_FRONTEND=noninteractive apt-get -qq --no-install-recommends install wireguard wireguard-tools -y
             elif [ "$linuxDistro" == "CentOS Stream" ] || [ "$linuxDistro" == "Fedora Linux" ]; then
                 sudo dnf -q install wireguard-tools -y


### PR DESCRIPTION
The apex agent installer script failed on an ubuntu 22.04 AMI on aws ec2. The issue was that the installer script was not able to install the wireguard package. The fix was to do an apt-get update prior to attempting the wireguard package install. This is generally a good thing to do in any case as well.

