### PR TITLE
apex: Add unix socket control interface

### DIFF
--- a/cmd/apexctl/local.go
+++ b/cmd/apexctl/local.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/rpc/jsonrpc"
+
+	"github.com/urfave/cli/v2"
+)
+
+func callApex(method string) (string, error) {
+	conn, err := net.Dial("unix", "/run/apex.sock")
+	if err != nil {
+		fmt.Printf("Failed to connect to apexd: %+v", err)
+		return "", err
+	}
+	defer conn.Close()
+
+	client := jsonrpc.NewClient(conn)
+
+	var result string
+	err = client.Call("ApexCtl."+method, nil, &result)
+	if err != nil {
+		fmt.Printf("Failed to execute method (%s): %+v", method, err)
+		return "", err
+	}
+	return result, nil
+}
+
+func checkVersion() error {
+	result, err := callApex("Version")
+	if err != nil {
+		fmt.Printf("Failed to get apexd version: %+v\n", err)
+		return err
+	}
+
+	if Version != result {
+		errMsg := fmt.Sprintf("Version mismatch: apexctl(%s) apexd(%s)\n", Version, result)
+		fmt.Print(errMsg)
+		return fmt.Errorf("%s", errMsg)
+	}
+
+	return nil
+}
+
+func cmdLocalVersion(cCtx *cli.Context) error {
+	fmt.Printf("apex version: %s\n", Version)
+
+	result, err := callApex("Version")
+	if err == nil {
+		fmt.Printf("apexd version: %s\n", result)
+	}
+	return err
+}
+
+func cmdLocalStatus(cCtx *cli.Context) error {
+	if err := checkVersion(); err != nil {
+		return err
+	}
+
+	result, err := callApex("Status")
+	if err == nil {
+		fmt.Print(result)
+	}
+	return err
+}

--- a/cmd/apexctl/main.go
+++ b/cmd/apexctl/main.go
@@ -19,6 +19,9 @@ const (
 	encodeColumn     = "column"
 )
 
+// This variable is set using ldflags at build time. See Makefile for details.
+var Version = "dev"
+
 func main() {
 	app := &cli.App{
 		Name: "apexctl",
@@ -35,14 +38,12 @@ func main() {
 				Usage: "api server",
 			},
 			&cli.StringFlag{
-				Name:     "username",
-				Required: true,
-				Usage:    "username",
+				Name:  "username",
+				Usage: "username",
 			},
 			&cli.StringFlag{
-				Name:     "password",
-				Required: true,
-				Usage:    "password",
+				Name:  "password",
+				Usage: "password",
 			},
 			&cli.StringFlag{
 				Name:     "output",
@@ -53,6 +54,30 @@ func main() {
 		},
 		Commands: []*cli.Command{
 			{
+				Name:  "version",
+				Usage: "Get the version of apexctl",
+				Action: func(cCtx *cli.Context) error {
+					fmt.Printf("version: %s\n", Version)
+					return nil
+				},
+			},
+			{
+				Name:  "apexd",
+				Usage: "commands for interacting with the local instance of apexd",
+				Subcommands: []*cli.Command{
+					{
+						Name:   "version",
+						Usage:  "apexd version",
+						Action: cmdLocalVersion,
+					},
+					{
+						Name:   "status",
+						Usage:  "apexd status",
+						Action: cmdLocalStatus,
+					},
+				},
+			},
+			{
 				Name:  "organization",
 				Usage: "commands relating to organizations",
 				Subcommands: []*cli.Command{
@@ -61,7 +86,7 @@ func main() {
 						Usage: "list organizations",
 						Action: func(cCtx *cli.Context) error {
 							c, err := client.NewClient(cCtx.Context,
-								cCtx.String("host"),
+								cCtx.String("host"), nil,
 								client.WithPasswordGrant(
 									cCtx.String("username"),
 									cCtx.String("password"),
@@ -97,7 +122,7 @@ func main() {
 						},
 						Action: func(cCtx *cli.Context) error {
 							c, err := client.NewClient(cCtx.Context,
-								cCtx.String("host"),
+								cCtx.String("host"), nil,
 								client.WithPasswordGrant(
 									cCtx.String("username"),
 									cCtx.String("password"),
@@ -125,7 +150,7 @@ func main() {
 						},
 						Action: func(cCtx *cli.Context) error {
 							c, err := client.NewClient(cCtx.Context,
-								cCtx.String("host"),
+								cCtx.String("host"), nil,
 								client.WithPasswordGrant(
 									cCtx.String("username"),
 									cCtx.String("password"),
@@ -157,7 +182,7 @@ func main() {
 						},
 						Action: func(cCtx *cli.Context) error {
 							c, err := client.NewClient(cCtx.Context,
-								cCtx.String("host"),
+								cCtx.String("host"), nil,
 								client.WithPasswordGrant(
 									cCtx.String("username"),
 									cCtx.String("password"),
@@ -190,7 +215,7 @@ func main() {
 						},
 						Action: func(cCtx *cli.Context) error {
 							c, err := client.NewClient(cCtx.Context,
-								cCtx.String("host"),
+								cCtx.String("host"), nil,
 								client.WithPasswordGrant(
 									cCtx.String("username"),
 									cCtx.String("password"),
@@ -215,7 +240,7 @@ func main() {
 						Usage: "list all users",
 						Action: func(cCtx *cli.Context) error {
 							c, err := client.NewClient(cCtx.Context,
-								cCtx.String("host"),
+								cCtx.String("host"), nil,
 								client.WithPasswordGrant(
 									cCtx.String("username"),
 									cCtx.String("password"),
@@ -233,7 +258,7 @@ func main() {
 						Usage: "get current user",
 						Action: func(cCtx *cli.Context) error {
 							c, err := client.NewClient(cCtx.Context,
-								cCtx.String("host"),
+								cCtx.String("host"), nil,
 								client.WithPasswordGrant(
 									cCtx.String("username"),
 									cCtx.String("password"),
@@ -257,7 +282,7 @@ func main() {
 						},
 						Action: func(cCtx *cli.Context) error {
 							c, err := client.NewClient(cCtx.Context,
-								cCtx.String("host"),
+								cCtx.String("host"), nil,
 								client.WithPasswordGrant(
 									cCtx.String("username"),
 									cCtx.String("password"),

--- a/cmd/apexd/main.go
+++ b/cmd/apexd/main.go
@@ -18,6 +18,9 @@ const (
 	apexLogEnv = "APEX_LOGLEVEL"
 )
 
+// This variable is set using ldflags at build time. See Makefile for details.
+var Version = "dev"
+
 func main() {
 	// set the log level
 	debug := os.Getenv(apexLogEnv)
@@ -143,6 +146,7 @@ func main() {
 				cCtx.Bool("stun"),
 				cCtx.Bool("hub-router"),
 				cCtx.Bool("relay-only"),
+				Version,
 			)
 			if err != nil {
 				logger.Fatal(err.Error())

--- a/integration-tests/util_test.go
+++ b/integration-tests/util_test.go
@@ -127,7 +127,7 @@ func (suite *ApexIntegrationSuite) CreateNode(ctx context.Context, name string, 
 }
 
 func newClient(ctx context.Context, username, password string) (*client.Client, error) {
-	return client.NewClient(ctx, "http://api.apex.local", client.WithPasswordGrant(username, password))
+	return client.NewClient(ctx, "http://api.apex.local", nil, client.WithPasswordGrant(username, password))
 }
 
 func getContainerIfaceIP(ctx context.Context, dev string, ctr testcontainers.Container) (string, error) {

--- a/internal/apex/ctlserver.go
+++ b/internal/apex/ctlserver.go
@@ -1,0 +1,134 @@
+package apex
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"os"
+	"sync"
+
+	"github.com/redhat-et/apex/internal/util"
+)
+
+// TODO make this path configurable
+const UnixSocketPath = "/run/apex.sock"
+
+func (ax *Apex) CtlServerStart(ctx context.Context, wg *sync.WaitGroup) error {
+	switch ax.os {
+	case Linux.String():
+		ax.CtlServerLinuxStart(ctx, wg)
+
+	case Darwin.String():
+		ax.logger.Info("Ctl interface not yet supported on OSX")
+
+	case Windows.String():
+		ax.logger.Info("Ctl interface not yet supported on Windows")
+	}
+
+	return nil
+}
+
+type ApexCtl struct {
+	ax *Apex
+}
+
+func (ac *ApexCtl) Status(_ string, result *string) error {
+	var statusStr string
+	switch ac.ax.status {
+	case ApexStatusStarting:
+		statusStr = "Starting"
+	case ApexStatusAuth:
+		statusStr = "WaitingForAuth"
+	case ApexStatusRunning:
+		statusStr = "Running"
+	default:
+		statusStr = "Unknown"
+	}
+	res := fmt.Sprintf("Status: %s\n", statusStr)
+	if len(ac.ax.statusMsg) > 0 {
+		res += ac.ax.statusMsg
+	}
+	*result = res
+	return nil
+}
+
+func (ac *ApexCtl) Version(_ string, result *string) error {
+	*result = ac.ax.version
+	return nil
+}
+
+func (ax *Apex) CtlServerLinuxStart(ctx context.Context, wg *sync.WaitGroup) {
+	util.GoWithWaitGroup(wg, func() {
+		for {
+			// Use a different waitgroup here, because we want to make sure
+			// all of the subroutines have exited before we attempt to restart
+			// the control server.
+			ctlWg := &sync.WaitGroup{}
+			err := ax.CtlServerLinuxRun(ctx, ctlWg)
+			ctlWg.Done()
+			if err == nil {
+				// No error means it shut down cleanly because it got a message to stop
+				break
+			}
+			ax.logger.Error("Ctl interface error, restarting: ", err)
+		}
+	})
+}
+
+func (ax *Apex) CtlServerLinuxRun(ctx context.Context, ctlWg *sync.WaitGroup) error {
+	os.Remove(UnixSocketPath)
+	l, err := net.ListenUnix("unix", &net.UnixAddr{Name: UnixSocketPath, Net: "unix"})
+	if err != nil {
+		ax.logger.Error("Error creating unix socket: ", err)
+		return err
+	}
+	defer l.Close()
+
+	ac := new(ApexCtl)
+	ac.ax = ax
+	err = rpc.Register(ac)
+	if err != nil {
+		ax.logger.Error("Error on rpc.Register(): ", err)
+		return err
+	}
+
+	// This routine will exit when the listener is closed intentionally,
+	// or some error occurs.
+	errChan := make(chan error)
+	util.GoWithWaitGroup(ctlWg, func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				errChan <- err
+				break
+			}
+			util.GoWithWaitGroup(ctlWg, func() {
+				jsonrpc.ServeConn(conn)
+			})
+		}
+	})
+
+	// Handle new connections until we get notified to stop the CtlServer,
+	// or Accept() fails for some reason.
+	stopNow := false
+	for {
+		select {
+		case err = <-errChan:
+			// Accept() failed, collect the error and stop the CtlServer
+			stopNow = true
+			ax.logger.Error("Error on Accept(): ", err)
+			break
+		case <-ctx.Done():
+			ax.logger.Info("Stopping CtlServer")
+			stopNow = true
+			err = nil
+		}
+		if stopNow {
+			break
+		}
+	}
+
+	return err
+}

--- a/internal/client/auth.go
+++ b/internal/client/auth.go
@@ -22,17 +22,21 @@ type deviceFlowResponse struct {
 	Interval                int    `json:"interval"`
 }
 
-func newDeviceFlowToken(ctx context.Context, deviceEndpoint, tokenEndpoint, clientID string) (*oauth2.Token, interface{}, error) {
+func newDeviceFlowToken(ctx context.Context, deviceEndpoint, tokenEndpoint, clientID string, authcb func(string)) (*oauth2.Token, interface{}, error) {
 	requestTime := time.Now()
 	d, err := startDeviceFlow(deviceEndpoint, clientID)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	fmt.Println("Your device must be registered with Apex.")
-	fmt.Printf("Your one-time code is: %s\n", d.UserCode)
-	fmt.Println("Please open the following URL in your browser to sign in:")
-	fmt.Printf("%s\n", d.VerificationURIComplete)
+	msg := fmt.Sprintf("Your device must be registered with Apex.\n"+
+		"Your one-time code is: %s\n"+
+		"Please open the following URL in your browser to sign in:\n%s\n",
+		d.UserCode, d.VerificationURIComplete)
+	fmt.Print(msg)
+	if authcb != nil {
+		authcb(msg)
+	}
 
 	var token *oauth2.Token
 	var idToken interface{}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -18,7 +18,7 @@ type Client struct {
 	client  *http.Client
 }
 
-func NewClient(ctx context.Context, addr string, options ...Option) (*Client, error) {
+func NewClient(ctx context.Context, addr string, authcb func(string), options ...Option) (*Client, error) {
 	opts, err := newOptions(options...)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ func NewClient(ctx context.Context, addr string, options ...Option) (*Client, er
 	var token *oauth2.Token
 	var rawIdToken interface{}
 	if c.options.deviceFlow {
-		token, rawIdToken, err = newDeviceFlowToken(ctx, resp.DeviceAuthURL, provider.Endpoint().TokenURL, resp.ClientID)
+		token, rawIdToken, err = newDeviceFlowToken(ctx, resp.DeviceAuthURL, provider.Endpoint().TokenURL, resp.ClientID, authcb)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
    Add a unix socket control interface on linux. This interface uses
    jsonrpc and supports checking the status apexd. It will report back
    the info needed to register the device if it's waiting for auth. This
    would be one way to get info when running apex as a daemon. The other
    would be from the daemon logs.
    
    apexctl now knows how to retrieve this status information by running:
    
        apexctl apexd status
    
    We now embed a version at build time into each binary. This is done
    using ldflags to set the value of main.Version.
    
    apexctl can report its own version.
    
        apexctl version
    
    apexctl can also report the version of a running apexd.
    
        apexctl apexd version
    
    When running subcommands of "apexctl apexd" other than "version",
    apexctl will first validate that the apexctl and apexd versions match.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>