### PR TITLE
fix: include the trace id in more of the logged messages.

### DIFF
--- a/internal/routers/middleware.go
+++ b/internal/routers/middleware.go
@@ -1,6 +1,7 @@
 package routers
 
 import (
+	"github.com/redhat-et/apex/internal/util"
 	"net/http"
 	"strings"
 
@@ -24,6 +25,7 @@ type Claims struct {
 // Naive JWS Key validation
 func ValidateJWT(logger *zap.SugaredLogger, verifier *oidc.IDTokenVerifier, clientIdWeb string, clientIdCli string) func(*gin.Context) {
 	return func(c *gin.Context) {
+		logger := util.WithTrace(c.Request.Context(), logger)
 		authz := c.Request.Header.Get("Authorization")
 		if authz == "" {
 			c.AbortWithStatus(http.StatusUnauthorized)

--- a/internal/routers/routers.go
+++ b/internal/routers/routers.go
@@ -47,9 +47,9 @@ func NewAPIRouter(
 	}
 	p.Use(r)
 
-	r.Use(ginzap.Ginzap(logger.Desugar(), time.RFC3339, true))
-	r.Use(ginzap.RecoveryWithZap(logger.Desugar(), true))
 	r.Use(otelgin.Middleware(name))
+	r.Use(ginzap.GinzapWithConfig(logger.Desugar(), &ginzap.Config{TimeFormat: time.RFC3339, UTC: true, TraceID: true}))
+	r.Use(ginzap.RecoveryWithZap(logger.Desugar(), true))
 
 	r.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"message": "ok"})

--- a/internal/util/with_trace.go
+++ b/internal/util/with_trace.go
@@ -9,7 +9,7 @@ import (
 func WithTrace(ctx context.Context, l *zap.SugaredLogger) *zap.SugaredLogger {
 	sc := trace.SpanFromContext(ctx).SpanContext()
 	if sc.HasTraceID() {
-		l = l.With(zap.String("trace-id", sc.TraceID().String()))
+		l = l.With(zap.String("traceID", sc.TraceID().String()))
 	}
 	return l
 }


### PR DESCRIPTION
use traceID as the key to be consistent with what the ginzap middleware does.

Signed-off-by: Hiram Chirino <hiram@hiramchirino.com>