### PR TITLE
Handle http errors in peer listings

### DIFF
--- a/internal/apex/apex.go
+++ b/internal/apex/apex.go
@@ -265,7 +265,7 @@ func (ax *Apex) Run() error {
 		if err := ax.Reconcile(user.ZoneID, false); err != nil {
 			// TODO: Add smarter reconciliation logic
 			// to handle disconnects and/or timeouts etc...
-			ax.logger.Error(err)
+			ax.logger.Errorf("Failed to reconcile state with the apex API server: ", err)
 		}
 	}
 	return nil

--- a/internal/apex/apex.go
+++ b/internal/apex/apex.go
@@ -265,7 +265,7 @@ func (ax *Apex) Run() error {
 		if err := ax.Reconcile(user.ZoneID, false); err != nil {
 			// TODO: Add smarter reconciliation logic
 			// to handle disconnects and/or timeouts etc...
-			return err
+			ax.logger.Error(err)
 		}
 	}
 	return nil

--- a/internal/client/peers.go
+++ b/internal/client/peers.go
@@ -82,7 +82,7 @@ func (c *Client) GetZonePeers(zoneID uuid.UUID) ([]models.Peer, error) {
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return nil, err
+		return nil, fmt.Errorf("http error code: %d", res.StatusCode)
 	}
 
 	var peerListing []models.Peer


### PR DESCRIPTION
- Prevents peer deletion if the peer lookup fails and throws an error instead of fataling out.

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>