### PR TITLE
ci: Add concurrency to deploy jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,7 @@
 name: deploy
 
+concurrency: qa-${{ github.ref_name }}
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,5 +1,7 @@
 name: promote
 
+concurrency: prod-${{ github.ref_name }}
+
 on:
   workflow_call:
   workflow_dispatch:


### PR DESCRIPTION
This should stop multiple concurrent merges racing to update the QA or Production images via kustomize

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>