### PR TITLE
Properly update the hub-router status of the device

### DIFF
--- a/internal/handlers/peer.go
+++ b/internal/handlers/peer.go
@@ -168,6 +168,7 @@ func (api *API) CreatePeerInZone(c *gin.Context) {
 		peer.EndpointIP = request.EndpointIP
 		peer.SymmetricNat = request.SymmetricNat
 		peer.ChildPrefix = request.ChildPrefix
+		peer.HubRouter = request.HubRouter
 
 		if request.NodeAddress != peer.NodeAddress {
 			var ip string


### PR DESCRIPTION
If a device joins as a normal device and after a disconnect it joins again as a hub-router, the peer list doesn't update the hub-router status in the GUI. Same happens if the device joins as a hub router and then as a normal device after disconnect.

Resolves #183 
Signed-off-by: Anil Kumar Vishnoi <avishnoi@redhat.com>