### PR TITLE
Cancel the in-progress build job on new commit/force push 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ on:
       - "**/*.md"
       - "**/*.gitignore"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Cancel the in-progress build job if new commit/force push done to same pr, avoid unnecessary queuing. 

Signed-off-by: Anil Kumar Vishnoi <avishnoi@redhat.com>