### PR TITLE
Add offline_access option for OIDC token refresh

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -52,7 +52,7 @@ func NewClient(ctx context.Context, addr string, options ...Option) (*Client, er
 		ClientID:     resp.ClientID,
 		ClientSecret: c.options.clientSecret,
 		Endpoint:     provider.Endpoint(),
-		Scopes:       []string{"openid", "profile", "email"},
+		Scopes:       []string{"openid", "profile", "email", "offline_access"},
 	}
 
 	var token *oauth2.Token


### PR DESCRIPTION
- To fetch the original token to refresh the token grant after the default 10hrs we need to enable the oidc offline_access option

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>