### PR TITLE
Run yaml-lint with --strict to prevent yaml lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: YAML Lint
         run: |
-          yamllint -c .yamllint.yaml deploy
+          yamllint -c .yamllint.yaml deploy --strict
 
       - uses: actions/setup-go@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,15 @@ go-lint: $(APEXD_DEPS) $(APISERVER_DEPS) ## Lint the go code
 	fi
 	golangci-lint run ./...
 
+.PHONY: yaml-lint
+yaml-lint: ## Lint the yaml files
+	@if ! which yamllint 2>&1 >/dev/null; then \
+		echo "Please install yamllint." ; \
+		echo "See: https://yamllint.readthedocs.io/en/stable/quickstart.html" ; \
+		exit 1 ; \
+	fi
+	yamllint -c .yamllint.yaml deploy --strict
+
 .PHONY: gen-docs
 gen-docs: ## Generate API docs
 	swag init -g ./cmd/apiserver/main.go -o ./internal/docs

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ help:
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 .PHONY: all
-all: go-lint apexd
+all: go-lint yaml-lint apexd
 
 ##@ Binaries
 


### PR DESCRIPTION
warning creeping in and showing up in the PRs
under "Unchanged files related warnings"

Also added make target yaml-lint so that dev's can run it locally before pushing the patch.

Signed-off-by: Anil Kumar Vishnoi <avishnoi@redhat.com>