### PR TITLE
lint: Add errorlint for go code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.50.0
-          args: --enable gosec
+          args: --enable gosec,errorlint
 
   ui-lint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ go-lint: $(APEXD_DEPS) $(APISERVER_DEPS) ## Lint the go code
 		echo "See: https://golangci-lint.run/usage/install/#local-installation" ; \
 		exit 1 ; \
 	fi
-	golangci-lint run --enable gosec ./...
+	golangci-lint run --enable gosec,errorlint ./...
 
 .PHONY: yaml-lint
 yaml-lint: ## Lint the yaml files

--- a/internal/apex/keepalive.go
+++ b/internal/apex/keepalive.go
@@ -86,7 +86,7 @@ func (p *dialer) ping(host string, i uint64, waitFor time.Duration) (string, err
 	netname := "ip4:icmp"
 	c, err := p.dial(netname, host)
 	if err != nil {
-		return "", fmt.Errorf("net.Dial(%v %v) failed: %v", netname, host, err)
+		return "", fmt.Errorf("net.Dial(%v %v) failed: %w", netname, host, err)
 	}
 	defer c.Close()
 	// send echo request
@@ -101,7 +101,7 @@ func (p *dialer) ping(host string, i uint64, waitFor time.Duration) (string, err
 	binary.BigEndian.PutUint16(msg[4:], uint16(i>>16))
 	binary.BigEndian.PutUint16(msg[2:], cksum(msg))
 	if _, err := c.Write(msg[:]); err != nil {
-		return "", fmt.Errorf("write failed: %v", err)
+		return "", fmt.Errorf("write failed: %w", err)
 	}
 	// get echo reply
 	if err = c.SetDeadline(time.Now().Add(waitFor)); err != nil {
@@ -111,7 +111,7 @@ func (p *dialer) ping(host string, i uint64, waitFor time.Duration) (string, err
 	before := time.Now()
 	amt, err := c.Read(rmsg[:])
 	if err != nil {
-		return "", fmt.Errorf("read failed: %v", err)
+		return "", fmt.Errorf("read failed: %w", err)
 	}
 	latency := time.Since(before)
 
@@ -141,7 +141,7 @@ func ping(host string) error {
 	for i := uint64(0); i <= iterations; i++ {
 		_, err := p.ping(host, i+1, waitFor)
 		if err != nil {
-			return fmt.Errorf("ping failed: %v", err)
+			return fmt.Errorf("ping failed: %w", err)
 		}
 		// TODO: this is probably irrelevant on one iteration
 		time.Sleep(time.Millisecond * interval)

--- a/internal/apex/keys.go
+++ b/internal/apex/keys.go
@@ -37,7 +37,7 @@ func (ax *Apex) handleKeys() error {
 		}
 		ax.logger.Infof("No existing public/private key pair found, generating a new pair")
 		if err := ax.generateKeyPair(darwinPublicKeyFile, darwinPrivateKeyFile); err != nil {
-			return fmt.Errorf("Unable to locate or generate a key/pair %v", err)
+			return fmt.Errorf("Unable to locate or generate a key/pair: %w", err)
 		}
 		ax.logger.Debugf("New keys were written to [ %s ] and [ %s ]", darwinPublicKeyFile, darwinPrivateKeyFile)
 		return nil
@@ -53,7 +53,7 @@ func (ax *Apex) handleKeys() error {
 		}
 		ax.logger.Infof("No existing public/private key pair found, generating a new pair")
 		if err := ax.generateKeyPair(windowsPublicKeyFile, windowsPrivateKeyFile); err != nil {
-			return fmt.Errorf("Unable to locate or generate a key/pair %v", err)
+			return fmt.Errorf("Unable to locate or generate a key/pair: %w", err)
 		}
 		ax.logger.Debugf("New keys were written to [ %s ] and [ %s ]", windowsPublicKeyFile, windowsPrivateKeyFile)
 		return nil
@@ -69,7 +69,7 @@ func (ax *Apex) handleKeys() error {
 		}
 		ax.logger.Infof("No existing public/private key pair found, generating a new pair")
 		if err := ax.generateKeyPair(linuxPublicKeyFile, linuxPrivateKeyFile); err != nil {
-			return fmt.Errorf("Unable to locate or generate a key/pair %v", err)
+			return fmt.Errorf("Unable to locate or generate a key/pair: %w", err)
 		}
 		ax.logger.Debugf("New keys were written to [ %s ] and [ %s ]", linuxPublicKeyFile, linuxPrivateKeyFile)
 		return nil
@@ -82,14 +82,14 @@ func (ax *Apex) generateKeyPair(publicKeyFile, privateKeyFile string) error {
 	cmd := exec.Command(wgBinary, "genkey")
 	privateKey, err := cmd.Output()
 	if err != nil {
-		return fmt.Errorf("wg genkey error %s", err)
+		return fmt.Errorf("wg genkey error: %w", err)
 	}
 
 	cmd = exec.Command(wgBinary, "pubkey")
 	cmd.Stdin = bytes.NewReader(privateKey)
 	publicKey, err := cmd.Output()
 	if err != nil {
-		return fmt.Errorf("wg pubkey error: %s", err)
+		return fmt.Errorf("wg pubkey error: %w", err)
 	}
 	ax.wireguardPubKey = strings.TrimSpace(string(publicKey))
 	ax.wireguardPvtKey = strings.TrimSpace(string(privateKey))
@@ -121,7 +121,7 @@ func readKeyFile(logger *zap.SugaredLogger, keyFile string) string {
 func readKeyFileToString(s string) (string, error) {
 	buf, err := os.ReadFile(s)
 	if err != nil {
-		return "", fmt.Errorf("unable to read file: %v\n", err)
+		return "", fmt.Errorf("unable to read file: %w", err)
 	}
 	rawStr := string(buf)
 	return strings.Replace(rawStr, "\n", "", -1), nil

--- a/internal/apex/stun.go
+++ b/internal/apex/stun.go
@@ -22,7 +22,7 @@ func IsSymmetricNAT(logger *zap.SugaredLogger) (bool, error) {
 	// get a random port to source the request from since the wg port may be bound
 	srcPort, err := getWgListenPort()
 	if err != nil {
-		return false, fmt.Errorf("failed to queury the STUN server %s: %+v", stunServer1, err)
+		return false, fmt.Errorf("failed to queury the STUN server %s: %w", stunServer1, err)
 	}
 	firstStun, err := StunRequest(logger, stunServer1, srcPort)
 	if err != nil {
@@ -52,12 +52,12 @@ func StunRequest(logger *zap.SugaredLogger, stunServer string, srcPort int) (str
 	conn, err := d.Dial("udp4", stunServer)
 	if err != nil {
 		logger.Errorf("stun dialing timed out %v", err)
-		return "", fmt.Errorf("failed to dial stun server %s: %v", stunServer, err)
+		return "", fmt.Errorf("failed to dial stun server %s: %w", stunServer, err)
 	}
 
 	stunResults, err := stunDialer(logger, &conn)
 	if err != nil {
-		return "", fmt.Errorf("stun dialing timed out %v", err)
+		return "", fmt.Errorf("stun dialing timed out: %w", err)
 	}
 	return stunResults, nil
 }

--- a/internal/apex/utils.go
+++ b/internal/apex/utils.go
@@ -45,7 +45,7 @@ func RunCommand(cmd ...string) (string, error) {
 	// #nosec -- G204: Subprocess launched with a potential tainted input or cmd arguments
 	output, err := exec.Command(cmd[0], cmd[1:]...).CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("failed to run %q: %s (%s)", strings.Join(cmd, " "), err, output)
+		return "", fmt.Errorf("failed to run %q: %w (%s)", strings.Join(cmd, " "), err, output)
 	}
 	return string(output), nil
 }
@@ -70,7 +70,7 @@ func ValidateIp(ip string) error {
 func ValidateCIDR(cidr string) error {
 	_, _, err := net.ParseCIDR(cidr)
 	if err != nil {
-		return fmt.Errorf("%s is not a valid v4 or v6 IP prefix", err)
+		return fmt.Errorf("'%s' is not a valid v4 or v6 IP prefix: %w", cidr, err)
 	}
 	return nil
 }
@@ -129,7 +129,7 @@ func CreateDirectory(path string) error {
 	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
 		err := os.MkdirAll(path, os.ModePerm)
 		if err != nil {
-			return fmt.Errorf("failed to create the directory %s: %v", path, err)
+			return fmt.Errorf("failed to create the directory %s: %w", path, err)
 		}
 	}
 	return nil

--- a/internal/apex/utils_linux.go
+++ b/internal/apex/utils_linux.go
@@ -14,12 +14,12 @@ import (
 func AddRoute(prefix, dev string) error {
 	link, err := netlink.LinkByName(dev)
 	if err != nil {
-		return fmt.Errorf("failed to lookup netlink device %s: %v", dev, err)
+		return fmt.Errorf("failed to lookup netlink device %s: %w", dev, err)
 	}
 
 	destNet, err := ParseIPNet(prefix)
 	if err != nil {
-		return fmt.Errorf("failed to parse a valid network address from %s: %v", prefix, err)
+		return fmt.Errorf("failed to parse a valid network address from %s: %w", prefix, err)
 	}
 
 	return route(destNet, link)
@@ -38,7 +38,7 @@ func route(ipNet *net.IPNet, dev netlink.Link) error {
 func RouteExists(prefix string) (bool, error) {
 	destNet, err := ParseIPNet(prefix)
 	if err != nil {
-		return false, fmt.Errorf("failed to parse a valid network address from %s: %v", prefix, err)
+		return false, fmt.Errorf("failed to parse a valid network address from %s: %w", prefix, err)
 	}
 
 	destRoute := &netlink.Route{Dst: destNet}
@@ -49,7 +49,7 @@ func RouteExists(prefix string) (bool, error) {
 
 	match, err := netlink.RouteListFiltered(family, destRoute, netlink.RT_FILTER_DST)
 	if err != nil {
-		return true, fmt.Errorf("error retrieving netlink routes: %v", err)
+		return true, fmt.Errorf("error retrieving netlink routes: %w", err)
 	}
 
 	if len(match) > 0 {
@@ -62,16 +62,16 @@ func RouteExists(prefix string) (bool, error) {
 func discoverLinuxAddress(logger *zap.SugaredLogger, family int) (net.IP, error) {
 	iface, _, err := getDefaultGatewayIface(logger, family)
 	if err != nil {
-		return nil, fmt.Errorf("%v", err)
+		return nil, fmt.Errorf("%w", err)
 	}
 
 	ips, err := getNetworkInterfaceIPs(iface)
 	if err != nil {
-		return nil, fmt.Errorf("%v", err)
+		return nil, fmt.Errorf("%w", err)
 	}
 
 	if len(ips) == 0 {
-		return nil, fmt.Errorf("%v", err)
+		return nil, fmt.Errorf("%w", err)
 	}
 
 	return ips[0].IP, nil
@@ -81,12 +81,12 @@ func discoverLinuxAddress(logger *zap.SugaredLogger, family int) (net.IP, error)
 func getNetworkInterfaceIPs(iface string) ([]*net.IPNet, error) {
 	link, err := netlink.LinkByName(iface)
 	if err != nil {
-		return nil, fmt.Errorf("failed to lookup link %s: %v", iface, err)
+		return nil, fmt.Errorf("failed to lookup link %s: %w", iface, err)
 	}
 
 	addrs, err := netlink.AddrList(link, netlink.FAMILY_ALL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list addresses for %q: %v", iface, err)
+		return nil, fmt.Errorf("failed to list addresses for %q: %w", iface, err)
 	}
 
 	var ips []*net.IPNet
@@ -108,7 +108,7 @@ func getDefaultGatewayIface(logger *zap.SugaredLogger, family int) (string, net.
 	filter := &netlink.Route{Dst: nil}
 	routes, err := netlink.RouteListFiltered(family, filter, netlink.RT_FILTER_DST)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to get routing table in node: %v", err)
+		return "", nil, fmt.Errorf("failed to get routing table in node: %w", err)
 	}
 	// use the first valid default gateway
 	for _, r := range routes {

--- a/internal/apex/wg-deploy.go
+++ b/internal/apex/wg-deploy.go
@@ -57,7 +57,7 @@ func (ax *Apex) DeployWireguardConfig(newPeers []models.Peer, firstTime bool) er
 		if newPeer.ID != uuid.Nil {
 			device, err := ax.client.GetDevice(newPeer.DeviceID)
 			if err != nil {
-				return fmt.Errorf("unable to get device %s: %s", newPeer.DeviceID, err)
+				return fmt.Errorf("unable to get device %s: %w", newPeer.DeviceID, err)
 			}
 			// add routes for each peer candidate (unless the key matches the local nodes key)
 			for _, peer := range cfg.Peers {

--- a/internal/apex/wg-iface.go
+++ b/internal/apex/wg-iface.go
@@ -116,7 +116,7 @@ func (ax *Apex) setupLinuxInterface(logger *zap.SugaredLogger) {
 
 func setupWindowsIface(logger *zap.SugaredLogger, localAddress, privateKey, dev string) error {
 	if err := buildWindowsWireguardIfaceConf(privateKey, localAddress); err != nil {
-		return fmt.Errorf("failed to create the windows wireguard wg0 interface file %v", err)
+		return fmt.Errorf("failed to create the windows wireguard wg0 interface file: %w", err)
 	}
 
 	var wgOut string
@@ -124,7 +124,7 @@ func setupWindowsIface(logger *zap.SugaredLogger, localAddress, privateKey, dev 
 	if ifaceExists(logger, dev) {
 		wgOut, err = RunCommand("wireguard.exe", "/uninstalltunnelservice", dev)
 		if err != nil {
-			logger.Debugf("failed to down the wireguard interface (this is generally ok): %v\n", err)
+			logger.Debugf("failed to down the wireguard interface (this is generally ok): %w", err)
 		}
 		if ifaceExists(logger, dev) {
 			logger.Debugf("existing windows iface %s has not been torn down yet, pausing for 1 second", dev)
@@ -135,7 +135,7 @@ func setupWindowsIface(logger *zap.SugaredLogger, localAddress, privateKey, dev 
 	// sleep for one second to give the wg async exe time to tear down any existing wg0 configuration
 	wgOut, err = RunCommand("wireguard.exe", "/installtunnelservice", windowsWgConfigFile)
 	if err != nil {
-		return fmt.Errorf("failed to start the wireguard interface: %v\n", err)
+		return fmt.Errorf("failed to start the wireguard interface: %w", err)
 	}
 	logger.Debugf("started windows tunnel svc: %v\n", wgOut)
 	// ensure the link is created before adding peers
@@ -145,7 +145,7 @@ func setupWindowsIface(logger *zap.SugaredLogger, localAddress, privateKey, dev 
 	}
 	// fatal out if the interface is not created
 	if !ifaceExists(logger, dev) {
-		return fmt.Errorf("failed to create the windows wireguard interface: %v\n", err)
+		return fmt.Errorf("failed to create the windows wireguard interface: %w", err)
 	}
 
 	return nil
@@ -205,7 +205,7 @@ func getIPv4Iface(ifname string) net.IP {
 func enableForwardingIPv4(logger *zap.SugaredLogger) error {
 	cmdOut, err := RunCommand("sysctl", "-w", "net.ipv4.ip_forward=1")
 	if err != nil {
-		return fmt.Errorf("failed to enable IP Forwarding for this hub-router: %v\n", err)
+		return fmt.Errorf("failed to enable IP Forwarding for this hub-router: %w", err)
 	}
 	logger.Debugf("%v", cmdOut)
 	return nil

--- a/internal/apex/wg.go
+++ b/internal/apex/wg.go
@@ -110,7 +110,7 @@ func (ax *Apex) handlePeerDelete(peerListing []models.Peer) error {
 		}
 		ax.logger.Debugf("Deleting peer with key: %s\n", ax.keyCache[p.DeviceID])
 		if err := ax.deletePeer(ax.keyCache[p.DeviceID], ax.tunnelIface); err != nil {
-			return fmt.Errorf("failed to delete peer: %v", err)
+			return fmt.Errorf("failed to delete peer: %w", err)
 		}
 		// delete the peer route(s)
 		ax.handlePeerRouteDelete(ax.tunnelIface, p)
@@ -132,7 +132,7 @@ func (ax *Apex) deletePeer(publicKey, dev string) error {
 
 	key, err := wgtypes.ParseKey(publicKey)
 	if err != nil {
-		return fmt.Errorf("failed to parse public key %s %v", publicKey, err)
+		return fmt.Errorf("failed to parse public key %s: %w", publicKey, err)
 	}
 
 	cfg := []wgtypes.PeerConfig{
@@ -148,7 +148,7 @@ func (ax *Apex) deletePeer(publicKey, dev string) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("failed to remove peer with key %s %v", key, err)
+		return fmt.Errorf("failed to remove peer with key %s: %w", key, err)
 	}
 
 	ax.logger.Infof("Removed peer with key %s", key)

--- a/internal/ipam/ipam.go
+++ b/internal/ipam/ipam.go
@@ -59,7 +59,7 @@ func (i *IPAM) AssignFromPool(parent context.Context, ipamPrefix string) (string
 		PrefixCidr: ipamPrefix,
 	}))
 	if err != nil {
-		return "", fmt.Errorf("failed to acquire an IPAM assigned address %v\n", err)
+		return "", fmt.Errorf("failed to acquire an IPAM assigned address %w\n", err)
 	}
 	return res.Msg.Ip.Ip, nil
 }
@@ -69,7 +69,7 @@ func (i *IPAM) AssignPrefix(parent context.Context, cidr string) error {
 	defer span.End()
 	cidr, err := cleanCidr(cidr)
 	if err != nil {
-		return fmt.Errorf("invalid prefix requested: %v", err)
+		return fmt.Errorf("invalid prefix requested: %w", err)
 	}
 
 	_, originalErr := i.client.CreatePrefix(ctx, connect.NewRequest(&apiv1.CreatePrefixRequest{Cidr: cidr}))
@@ -94,7 +94,7 @@ func (i *IPAM) ReleaseToPool(ctx context.Context, address, cidr string) error {
 	}))
 
 	if err != nil {
-		return fmt.Errorf("failed to release IPAM address %v", err)
+		return fmt.Errorf("failed to release IPAM address %w", err)
 	}
 	return nil
 }
@@ -106,7 +106,7 @@ func (i *IPAM) ReleasePrefix(ctx context.Context, cidr string) error {
 	}))
 
 	if err != nil {
-		return fmt.Errorf("failed to release IPAM prefix %v", err)
+		return fmt.Errorf("failed to release IPAM prefix %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
In most cases, we should be using %w for errors in format strings. The exception is when calling log functions, as they don't support it.

For more info:
    https://github.com/polyfloyd/go-errorlint

Signed-off-by: Russell Bryant <rbryant@redhat.com>