### PR TITLE
chore: apexd should shut down cleaner on an os signal.

### DIFF
--- a/internal/apex/apex.go
+++ b/internal/apex/apex.go
@@ -3,11 +3,13 @@ package apex
 import (
 	"context"
 	"fmt"
+	"github.com/redhat-et/apex/internal/util"
 	"net"
 	"net/url"
 	"os"
 	"reflect"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -168,7 +170,7 @@ func NewApex(ctx context.Context, logger *zap.SugaredLogger,
 	return ax, nil
 }
 
-func (ax *Apex) Run() error {
+func (ax *Apex) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	var err error
 
 	if err := ax.handleKeys(); err != nil {
@@ -240,37 +242,37 @@ func (ax *Apex) Run() error {
 		return err
 	}
 
-	// send keepalives to all peers on a ticker
+	// send keepalives to all peers periodically
 	if !ax.hubRouter {
-		go func() {
-			keepAliveTicker := time.NewTicker(time.Second * 10)
-			for range keepAliveTicker.C {
+		util.GoWithWaitGroup(wg, func() {
+			util.RunPeriodically(ctx, time.Second*10, func() {
 				ax.Keepalive()
-			}
-		}()
+			})
+		})
 	}
 
-	// gather wireguard state from the relay node on a ticker
+	// gather wireguard state from the relay node periodically
 	if ax.hubRouter {
-		go func() {
-			relayStateTicker := time.NewTicker(time.Second * 30)
-			for range relayStateTicker.C {
+		util.GoWithWaitGroup(wg, func() {
+			util.RunPeriodically(ctx, time.Second*30, func() {
 				ax.logger.Debugf("Reconciling peers from relay state")
 				if err := ax.relayStateReconcile(user.ZoneID); err != nil {
 					ax.logger.Error(err)
 				}
-			}
-		}()
+			})
+		})
 	}
 
-	ticker := time.NewTicker(pollInterval)
-	for range ticker.C {
-		if err := ax.Reconcile(user.ZoneID, false); err != nil {
-			// TODO: Add smarter reconciliation logic
-			// to handle disconnects and/or timeouts etc...
-			ax.logger.Errorf("Failed to reconcile state with the apex API server: ", err)
-		}
-	}
+	util.GoWithWaitGroup(wg, func() {
+		util.RunPeriodically(ctx, pollInterval, func() {
+			if err := ax.Reconcile(user.ZoneID, false); err != nil {
+				// TODO: Add smarter reconciliation logic
+				// to handle disconnects and/or timeouts etc...
+				ax.logger.Errorf("Failed to reconcile state with the apex API server: ", err)
+			}
+		})
+	})
+
 	return nil
 }
 
@@ -400,10 +402,6 @@ func (ax *Apex) relayStateReconcile(zoneID uuid.UUID) error {
 			}
 		}
 	}
-	return nil
-}
-
-func (ax *Apex) Shutdown(ctx context.Context) error {
 	return nil
 }
 

--- a/internal/util/go_with_wait_group.go
+++ b/internal/util/go_with_wait_group.go
@@ -1,0 +1,17 @@
+package util
+
+import "sync"
+
+// GoWithWaitGroup runs fn in a goroutine with an optional *sync.WaitGroup to
+// track when fn finishes executing.
+func GoWithWaitGroup(wg *sync.WaitGroup, fn func()) {
+	if wg != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			fn()
+		}()
+	} else {
+		go fn()
+	}
+}

--- a/internal/util/go_with_wait_group_test.go
+++ b/internal/util/go_with_wait_group_test.go
@@ -1,0 +1,31 @@
+package util_test
+
+import (
+	"github.com/redhat-et/apex/internal/util"
+	"github.com/stretchr/testify/assert"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestGoWithWaitGroup(t *testing.T) {
+
+	// Verify you can use a nil WaitGroup
+	util.GoWithWaitGroup(nil, func() {
+	})
+
+	// Verify all goroutines are done before the WaitGroup counter is zero.
+	counter := atomic.Int32{}
+	wg := &sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		// run a few functions in parallel
+		util.GoWithWaitGroup(wg, func() {
+			time.Sleep(200 * time.Millisecond)
+			counter.Add(1)
+		})
+	}
+	wg.Wait()
+	assert.Equal(t, int32(10), counter.Load())
+
+}

--- a/internal/util/run_periodically.go
+++ b/internal/util/run_periodically.go
@@ -1,0 +1,19 @@
+package util
+
+import (
+	"context"
+	"time"
+)
+
+func RunPeriodically(ctx context.Context, duration time.Duration, fn func()) {
+	ticker := time.NewTicker(duration)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			fn()
+		}
+	}
+}


### PR DESCRIPTION
Make the api a little more go idiomatic by using a Context cancellation to signal to *Apex that it should shut down and wait for the cancellation to occur using a WaitGroup.

Signed-off-by: Hiram Chirino <hiram@hiramchirino.com>