### PR TITLE
fix: `make run-test-container` now works on osx

### DIFF
--- a/Containerfile.test
+++ b/Containerfile.test
@@ -34,6 +34,7 @@ RUN apt-get update -qy && \
     iproute2 \
     wireguard-tools \
     iptables \
+    net-tools \
     traceroute \
     tcpdump \
     conntrack \
@@ -44,4 +45,10 @@ COPY ./dist/apexd /bin/apexd
 COPY ./dist/apexctl /bin/apexctl
 COPY ./.certs/rootCA.pem /usr/local/share/ca-certificates/rootCA.crt
 RUN /usr/sbin/update-ca-certificates
+RUN echo "echo '\n\
+To connect this container to the apex network, try running:\n\
+\n\
+   /bin/apexd --username admin --password floofykittens https://apex.local\n\
+'" >> /root/.bashrc
+
 ENTRYPOINT [ "/bin/sleep", "infinity" ]

--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,9 @@ e2e: e2eprereqs dist/apexd dist/apexctl test-images ## Run e2e tests
 test: ## Run unit tests
 	go test -v ./...
 
-APEX_LOCAL_IP:=`getent hosts apex.local | awk '{ print $$1 }'`
+APEX_LOCAL_IP:=`go run ./hack/resolve-ip apex.local`
 .PHONY: run-test-container
-run-test-container: e2eprereqs dist/apexd dist/apexctl test-images ## Run docker container that you can run apex in
+run-test-container: dist/apexd dist/apexctl test-images ## Run docker container that you can run apex in
 	docker run --rm -it --network bridge \
 		--cap-add SYS_MODULE \
 		--cap-add NET_ADMIN \
@@ -103,14 +103,12 @@ e2eprereqs:
 	@if [ -z "$(shell which kind)" ]; then \
 		echo "Please install kind and then start the kind dev environment." ; \
 		echo "https://kind.sigs.k8s.io/" ; \
-		echo "  $$ hack/kind/kind.sh up" ; \
-		echo "  $$ hack/kind/kind.sh cacert" ; \
+		echo "  $$ make run-on-kind" ; \
 		exit 1 ; \
 	fi
 	@if [ -z "$(findstring apex-dev,$(shell kind get clusters))" ]; then \
 		echo "Please start the kind dev environment." ; \
-		echo "  $$ hack/kind/kind.sh up" ; \
-		echo "  $$ hack/kind/kind.sh cacert" ; \
+		echo "  $$ make run-on-kind" ; \
 		exit 1 ; \
 	fi
 

--- a/hack/resolve-ip/main.go
+++ b/hack/resolve-ip/main.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 
-	if len(os.Args) < 2 {
+	if len(os.Args) != 2 {
 		fmt.Fprintln(os.Stderr, "host argument missing")
 		os.Exit(1)
 	}

--- a/hack/resolve-ip/main.go
+++ b/hack/resolve-ip/main.go
@@ -15,7 +15,7 @@ func main() {
 	host := os.Args[1]
 	addrs, err := net.LookupHost(host)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %+v\n", err)
+		fmt.Fprintf(os.Stderr, "error: %w\n", err)
 		os.Exit(2)
 	}
 

--- a/hack/resolve-ip/main.go
+++ b/hack/resolve-ip/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+)
+
+func main() {
+
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "host argument missing")
+		os.Exit(1)
+	}
+	host := os.Args[1]
+	addrs, err := net.LookupHost(host)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %+v\n", err)
+		os.Exit(2)
+	}
+
+	for _, addr := range addrs {
+		fmt.Println(addr)
+		return
+	}
+}


### PR DESCRIPTION
Added info message when you start the test container so that beginners know what command they should run to get apexd up.

Added net-tools to the image incase you need to do some network troubleshooting. 

Fixed a Makefile message that referred to hack/kind/kind.sh