### PR TITLE
test: Fix a panic in a test

### DIFF
--- a/integration-tests/util_test.go
+++ b/integration-tests/util_test.go
@@ -68,7 +68,11 @@ func getContainerIfaceIP(ctx context.Context, dev string, ctr testcontainers.Con
 		if code != 0 {
 			return fmt.Errorf("exit code %d. output: %s", code, string(output))
 		}
-		cidr := strings.Fields(string(output))[2]
+		fields := strings.Fields(string(output))
+		if len(fields) < 3 {
+			return fmt.Errorf("Interface %s has no IP address", dev)
+		}
+		cidr := fields[2]
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This code assumed output was present in a certain format. If the interface exists, but has no IP address, this code will crash when trying to get a field out of empty output. This will catch it and return an error instead.

Signed-off-by: Russell Bryant <rbryant@redhat.com>