### PR TITLE
go-lint: Add a golangci-lint config file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,6 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.50.0
-          args: --enable gosec,errorlint
 
   ui-lint:
     runs-on: ubuntu-latest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,4 @@
+linters:
+  enable:
+    - gosec
+    - errorlint

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ go-lint: $(APEXD_DEPS) $(APISERVER_DEPS) ## Lint the go code
 		echo "See: https://golangci-lint.run/usage/install/#local-installation" ; \
 		exit 1 ; \
 	fi
-	golangci-lint run --enable gosec,errorlint ./...
+	golangci-lint run ./...
 
 .PHONY: yaml-lint
 yaml-lint: ## Lint the yaml files


### PR DESCRIPTION
Use a config file instead of duplicating configuration between the Makefile and the github actions job.

Closes #415

Signed-off-by: Russell Bryant <rbryant@redhat.com>