### PR TITLE
Github actions has some weirdness around evaluating

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: ["main"]
     paths-ignore:
-      - "**/*.md"
-      - "**/*.gitignore"
+      - '**/*.md'
+      - '**/*.gitignore'
   pull_request:
     branches: ["main"]
     paths-ignore:
-      - "**/*.md"
-      - "**/*.gitignore"
+      - '**/*.md'
+      - '**/*.gitignore'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
patterns in double quote vs single quote.

It's recommended to use single quote
https://docs.github.com/en/actions/learn-github-actions/expressions#literals