### PR TITLE
clean up: reduce code duplication in stun.go, use a dynamic port the wg interface that we can open.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,7 @@ redeploy: load-images ## Redploy apex after images changes
 recreate-db: recreate-db ## Delete and bring up a new apex database
 	@kubectl delete -n apex deploy/apiserver postgrescluster/database deploy/ipam
 	@kubectl apply -k ./deploy/apex/overlays/dev
+	@kubectl wait --for=condition=Ready pods --all -n apex -l app.kubernetes.io/part-of=apex --timeout=15m
 
 .PHONY: cacerts
 cacerts: ## Install the Self-Signed CA Certificate

--- a/internal/apex/stun.go
+++ b/internal/apex/stun.go
@@ -3,113 +3,28 @@ package apex
 import (
 	"fmt"
 	"github.com/libp2p/go-reuseport"
-	"net"
-	"strconv"
-	"time"
-
 	"github.com/pion/stun"
 	"go.uber.org/zap"
+	"net"
 )
 
 const (
+	stunServer  = "stun.l.google.com:19302"
 	stunServer1 = "stun1.l.google.com:19302"
 	stunServer2 = "stun2.l.google.com:19302"
 )
 
-// IsSymmetricNAT attempts to infer if the node is behind a symmetric
-// nat device by querying two STUN servers. If the requests return
-// different ports, then it is likely the node is behind a symmetric nat.
-func IsSymmetricNAT(logger *zap.SugaredLogger) (bool, error) {
-	// get a random port to source the request from since the wg port may be bound
-	srcPort, err := getWgListenPort()
-	if err != nil {
-		return false, fmt.Errorf("failed to query the STUN server %s: %w", stunServer1, err)
-	}
-	firstStun, err := StunRequest(logger, stunServer1, srcPort)
-	if err != nil {
-		return false, fmt.Errorf("failed to query the STUN server %s", stunServer1)
-	}
-	secondStun, err := StunRequest(logger, stunServer2, srcPort)
-	if err != nil {
-		return false, fmt.Errorf("failed to query the STUN server %s", stunServer1)
-	}
-	if firstStun != secondStun {
-		return true, nil
-	}
+func StunRequest(logger *zap.SugaredLogger, stunServer string, srcPort int) (net.UDPAddr, error) {
 
-	return false, nil
-}
-
-// StunRequest initiate a connection to a STUN server sourced from the wg src port
-func StunRequest(logger *zap.SugaredLogger, stunServer string, srcPort int) (string, error) {
-	lAddr := &net.UDPAddr{
-		Port: srcPort,
-	}
-	d := &net.Dialer{
-		Timeout:   3 * time.Second,
-		LocalAddr: lAddr,
-	}
 	logger.Debugf("dialing stun server %s", stunServer)
-	conn, err := d.Dial("udp4", stunServer)
+	conn, err := reuseport.Dial("udp", fmt.Sprintf(":%d", srcPort), stunServer)
 	if err != nil {
 		logger.Errorf("stun dialing timed out %v", err)
-		return "", fmt.Errorf("failed to dial stun server %s: %w", stunServer, err)
+		return net.UDPAddr{}, fmt.Errorf("failed to dial stun server %s: %w", stunServer, err)
 	}
-
-	stunResults, err := stunDialer(logger, &conn)
-	if err != nil {
-		return "", fmt.Errorf("Failed to find stun address %w", err)
-	}
-	return stunResults, nil
-}
-
-func stunDialer(logger *zap.SugaredLogger, conn *net.Conn) (string, error) {
-	c, err := stun.NewClient(*conn)
-	if err != nil {
-		logger.Errorf("Failed to open a stun socket %v", err)
-	}
-	var xorAddr stun.XORMappedAddress
-	if err = c.Do(stun.MustBuild(stun.TransactionID, stun.BindingRequest), func(res stun.Event) {
-		if res.Error != nil {
-			logger.Errorf("stun request error %v", res.Error)
-			return
-		}
-		if err := xorAddr.GetFrom(res.Message); err != nil {
-			logger.Errorf("stun request error %v", res)
-			if err := c.Close(); err != nil {
-				logger.Errorf("stun request error %v", res)
-				return
-			}
-			return
-		}
-		logger.Debugf("Stun address and port is: %s:%d", xorAddr.IP, xorAddr.Port)
-
-	}); err != nil {
-		return "", err
-	}
-	if err := c.Close(); err != nil {
-		return "", err
-	}
-	stunAddress := net.JoinHostPort(xorAddr.IP.String(), strconv.Itoa(xorAddr.Port))
-	if err != nil {
-		return "", err
-	}
-
-	return stunAddress, nil
-}
-
-// GetPublicUDPAddr retrieves current global net.UDPAddr address using STUN for a given local UDP port.
-func GetPublicUDPAddr(logger *zap.SugaredLogger, wgPort int) (net.UDPAddr, error) {
-
-	// Send a message to the stun server from the WG port.
-	conn, err := reuseport.Dial("udp", fmt.Sprintf(":%d", wgPort), "stun.l.google.com:19302")
 	defer func() {
 		_ = conn.Close()
 	}()
-
-	if err != nil {
-		panic(err)
-	}
 
 	c, err := stun.NewClient(conn)
 	if err != nil {
@@ -131,7 +46,7 @@ func GetPublicUDPAddr(logger *zap.SugaredLogger, wgPort int) (net.UDPAddr, error
 		if err := xorAddr.GetFrom(res.Message); err != nil {
 			return
 		}
-		logger.Debugf("STUN: your IP:port are: %s:%d", xorAddr.IP, xorAddr.Port)
+
 		result = net.UDPAddr{
 			IP:   xorAddr.IP,
 			Port: xorAddr.Port,
@@ -140,5 +55,9 @@ func GetPublicUDPAddr(logger *zap.SugaredLogger, wgPort int) (net.UDPAddr, error
 		logger.Error(err)
 		return net.UDPAddr{}, err
 	}
+	if result.IP.IsUnspecified() {
+		return result, fmt.Errorf("no public facing NAT address found for the host")
+	}
+	logger.Debugf("STUN: your IP:port is: %s", result)
 	return result, nil
 }

--- a/internal/apex/utils.go
+++ b/internal/apex/utils.go
@@ -108,7 +108,7 @@ func IsNAT(logger *zap.SugaredLogger, nodeOS, controller string, port string) (b
 		}
 		hostIP = linuxIP.String()
 	}
-	ipAndPort, err := GetPublicUDPAddr(logger, 0)
+	ipAndPort, err := StunRequest(logger, stunServer, 0)
 	if err != nil {
 		return false, err
 	}

--- a/internal/apex/wg.go
+++ b/internal/apex/wg.go
@@ -1,9 +1,7 @@
 package apex
 
 import (
-	"crypto/rand"
 	"fmt"
-	"math/big"
 	"net"
 	"strconv"
 	"time"
@@ -165,11 +163,18 @@ func inPeerListing(peers []models.Peer, p models.Peer) bool {
 }
 
 func getWgListenPort() (int, error) {
-	min := 32768
-	max := 61000
-	bInt, err := rand.Int(rand.Reader, big.NewInt(int64(max-min)))
+	l, err := net.ListenUDP("udp", &net.UDPAddr{})
 	if err != nil {
 		return 0, err
 	}
-	return int(bInt.Int64()) + min, nil
+	defer l.Close()
+	_, port, err := net.SplitHostPort(l.LocalAddr().String())
+	if err != nil {
+		return 0, err
+	}
+	p, err := strconv.Atoi(port)
+	if err != nil {
+		return 0, err
+	}
+	return p, nil
 }


### PR DESCRIPTION
Using a random high port for the wg is not guaranteed to not be in use by another process, so lets ask the OS for a dynamic port instead.

This now avoids an additional stun request once we have determined that the device is behind a symmetric nat.

Wait for apex to be deployed when running `make recreate-db`