### PR TITLE
Add .vscode directory to paths-ignore for build and doc job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,11 +6,13 @@ on:
     paths-ignore:
       - '**/*.md'
       - '**/*.gitignore'
+      - '.vscode/**'
   pull_request:
     branches: ["main"]
     paths-ignore:
       - '**/*.md'
       - '**/*.gitignore'
+      - '.vscode/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,10 +5,12 @@ on:
     branches: ["main"]
     paths:
       - '**/*.md'
+      - '.vscode/**'
   pull_request:
     branches: ["main"]
     paths:
       - '**/*.md'
+      - '.vscode/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
So that *.md only patches with any change in .vscode directory won't trigger build jobs.