### PR TITLE
apex: Use net.JoinHostPort()

### DIFF
--- a/internal/apex/apex.go
+++ b/internal/apex/apex.go
@@ -221,7 +221,7 @@ func (ax *Apex) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if ax.childPrefix != "" {
 		childPrefix = append(childPrefix, ax.childPrefix)
 	}
-	endpointSocket := fmt.Sprintf("%s:%d", localIP, localEndpointPort)
+	endpointSocket := net.JoinHostPort(localIP, fmt.Sprintf("%d", localEndpointPort))
 	device, err := ax.client.CreateDevice(models.AddDevice{
 		UserID:                   user.ID,
 		OrganizationID:           ax.zone,

--- a/internal/apex/wg-peers.go
+++ b/internal/apex/wg-peers.go
@@ -112,7 +112,7 @@ func (ax *Apex) buildPeersConfig() {
 
 		// if both nodes are local, peer them directly to one another via their local addresses (includes symmetric nat nodes)
 		if ax.nodeReflexiveAddress == value.ReflexiveIPv4 {
-			directLocalPeerEndpointSocket := fmt.Sprintf("%s:%s", value.EndpointLocalAddressIPv4, peerPort)
+			directLocalPeerEndpointSocket := net.JoinHostPort(value.EndpointLocalAddressIPv4, peerPort)
 			ax.logger.Infof("ICE candidate match for local address peering is [ %s ] with a STUN Address of [ %s ]", directLocalPeerEndpointSocket, value.ReflexiveIPv4)
 			// the symmetric NAT peer
 			for _, prefix := range value.ChildPrefix {


### PR DESCRIPTION
Update two spots joining an IP and port into a string to use the net.JoinHostPort() helper. This helper will ensure IPv6 addresses are handled properly. It doesn't matter now, but presumably it will eventually.