### PR TITLE
ci: Add an rpm build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -338,3 +338,15 @@ jobs:
       - name: copy binaries to s3
         run: |
           aws s3 sync . s3://apex-net/
+
+  build-rpm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v2
+      - name: Install make
+        run: |
+          sudo apt -y install make
+      - name: Build rpm
+        run: |
+          make rpm

--- a/Makefile
+++ b/Makefile
@@ -277,13 +277,13 @@ srpm: dist/rpm image-mock ## Build a source RPM
 	rm -rf dist/rpm/apex-${APEX_RELEASE}
 	rm -f dist/rpm/apex-${APEX_RELEASE}.tar.gz
 	git archive --format=tar.gz -o dist/rpm/apex-${APEX_RELEASE}.tar.gz --prefix=apex-${APEX_RELEASE}/ ${APEX_RELEASE}
-	cd dist/rpm && tar xvzf apex-${APEX_RELEASE}.tar.gz
+	cd dist/rpm && tar xzf apex-${APEX_RELEASE}.tar.gz
 	mv vendor dist/rpm/apex-${APEX_RELEASE}/.
-	cd dist/rpm && tar czvf apex-${APEX_RELEASE}.tar.gz apex-${APEX_RELEASE} && rm -rf apex-${APEX_RELEASE}
+	cd dist/rpm && tar czf apex-${APEX_RELEASE}.tar.gz apex-${APEX_RELEASE} && rm -rf apex-${APEX_RELEASE}
 	cp contrib/rpm/apex.spec.in contrib/rpm/apex.spec
 	sed -i -e "s/##APEX_COMMIT##/${APEX_RELEASE}/" contrib/rpm/apex.spec
 	docker rm -f mock || true
-	docker run --name mock --cap-add SYS_ADMIN -v $(CURDIR):/apex quay.io/apex/mock:latest \
+	docker run --name mock --privileged=true -v $(CURDIR):/apex quay.io/apex/mock:latest \
 		mock --buildsrpm -D "_commit ${APEX_RELEASE}" --resultdir=/apex/dist/rpm/mock \
 		--spec /apex/contrib/rpm/apex.spec --sources /apex/dist/rpm/ --root ${MOCK_ROOT}
 	rm -f dist/rpm/apex-${APEX_RELEASE}.tar.gz
@@ -291,7 +291,7 @@ srpm: dist/rpm image-mock ## Build a source RPM
 .PHONY: rpm
 rpm: srpm ## Build an RPM
 	docker rm -f mock || true
-	docker run --name mock --cap-add SYS_ADMIN -v $(CURDIR):/apex quay.io/apex/mock:latest \
+	docker run --name mock --privileged=true -v $(CURDIR):/apex quay.io/apex/mock:latest \
 		mock --rebuild --without check \--resultdir=/apex/dist/rpm/mock --root ${MOCK_ROOT} \
 		/apex/$(wildcard dist/rpm/mock/apex-*$(shell date +%Y%m%d)git$(APEX_RELEASE).$(SRPM_DISTRO).src.rpm)
 


### PR DESCRIPTION
Ensure the rpm build is functional via CI. --cap-add SYS_ADMIN didn't work in CI for some reason, so I switch to a privileged container. I also made the build a little less noisy.

Closes #436