### PR TITLE
Improve child-prefix network validation

### DIFF
--- a/internal/apex/apex.go
+++ b/internal/apex/apex.go
@@ -463,7 +463,7 @@ func (ax *Apex) checkUnsupportedConfigs() error {
 	}
 	if ax.childPrefix != "" {
 		if err := ValidateCIDR(ax.childPrefix); err != nil {
-			return fmt.Errorf("the CIDR prefix passed in --child-prefix %s was not valid: %w", ax.childPrefix, err)
+			return err
 		}
 	}
 	return nil

--- a/internal/apex/utils.go
+++ b/internal/apex/utils.go
@@ -68,10 +68,15 @@ func ValidateIp(ip string) error {
 
 // ValidateCIDR ensures a valid IP4/IP6 prefix is provided
 func ValidateCIDR(cidr string) error {
-	_, _, err := net.ParseCIDR(cidr)
+	_, netAddr, err := net.ParseCIDR(cidr)
 	if err != nil {
 		return fmt.Errorf("'%s' is not a valid v4 or v6 IP prefix: %w", cidr, err)
 	}
+
+	if cidr != netAddr.String() {
+		return fmt.Errorf("Invalid network prefix provided %s, try using %s\n", cidr, netAddr.String())
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
- Prevent a user from providing an invalid prefix. For example a prefix of 172.16.100.5/24 will now be rejected and valid prefix 172.16.100.0/24 is suggested in the error message.