### PR TITLE
ci: Move unit tests to their own job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
+  go-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
+      - id: go-cache-paths
+        shell: bash
+        run: |
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+
+      - name: Go Build Cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+
+      - name: Go Mod Cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
+      - name: Build
+        run: |
+          go build ./...
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.50.0
+
+  go-unit:
+    needs: go-lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -54,11 +92,6 @@ jobs:
       - name: Unit tests
         run: |
           go test -v ./...
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.50.0
 
   ui-lint:
     runs-on: ubuntu-latest
@@ -111,7 +144,7 @@ jobs:
           kubeconform -summary -output json -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' -schema-location 'deploy/.crdSchemas/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' kubeconfigs/
 
   build-images:
-    needs: lint
+    needs: go-lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -146,7 +179,7 @@ jobs:
           path: /tmp/frontend.tar
 
   build-binaries:
-    needs: lint
+    needs: go-lint
     strategy:
       fail-fast: false
       matrix:
@@ -216,7 +249,7 @@ jobs:
             ${{ steps.build-apexctl.outputs.artifact-name }}
 
   e2e:
-    needs: [lint, k8s-lint, build-images]
+    needs: [go-lint, go-unit, k8s-lint, build-images]
     name: e2e-integration
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,10 +47,6 @@ jobs:
           path: ${{ steps.go-cache-paths.outputs.go-mod }}
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
-      - name: Go Format
-        run: |
-          go fmt ./...
-
       - name: Build
         run: |
           go build ./...


### PR DESCRIPTION
```
commit b1305001d93283872c05a6c42a4c040ce338a95f (HEAD -> unit-ci-job, russellb/unit-ci-job)
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Feb 20 11:26:05 2023 -0500

    ci: Split unit tests out into their own job
    
    I was surprised to see the unit tests running in the lint job. This
    patch splits them out into their own job that runs after lint passes.
    
    This change also renames `lint` to `go-lint` to make the job name more
    explicit about the type of linting it is doing.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 35c65878cd30b989ea21368d2838e89c38358e71
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Feb 20 11:23:32 2023 -0500

    ci: Stop running go fmt
    
    This command silently fixes any formatting issues before running the
    linter. We should let the linter find the issues and then fail the CI
    job.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
```