### PR TITLE
Publish RPMs to a public repo after commits to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -369,3 +369,16 @@ jobs:
       - name: copy binaries to s3
         run: |
           aws s3 sync . s3://apex-net/
+
+  build-rpm:
+    needs: ["go-lint"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v2
+      - name: Install make
+        run: |
+          sudo apt -y install make
+      - name: Build rpm
+        run: |
+          make rpm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -375,7 +375,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: docker/setup-buildx-action@v2
       - name: Install make
         run: |
           sudo apt -y install make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
+  go-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
+      - id: go-cache-paths
+        shell: bash
+        run: |
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+
+      - name: Go Build Cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+
+      - name: Go Mod Cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
+      - name: Build
+        run: |
+          go build ./...
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.50.0
+
+  go-unit:
+    needs: go-lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -54,11 +92,6 @@ jobs:
       - name: Unit tests
         run: |
           go test -v ./...
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.50.0
 
   ui-lint:
     runs-on: ubuntu-latest
@@ -111,7 +144,7 @@ jobs:
           kubeconform -summary -output json -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' -schema-location 'deploy/.crdSchemas/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' kubeconfigs/
 
   build-images:
-    needs: lint
+    needs: go-lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -146,7 +179,7 @@ jobs:
           path: /tmp/frontend.tar
 
   build-binaries:
-    needs: lint
+    needs: go-lint
     strategy:
       fail-fast: false
       matrix:
@@ -216,7 +249,7 @@ jobs:
             ${{ steps.build-apexctl.outputs.artifact-name }}
 
   e2e:
-    needs: [lint, k8s-lint, build-images]
+    needs: [go-lint, go-unit, k8s-lint, build-images]
     name: e2e-integration
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,10 +47,6 @@ jobs:
           path: ${{ steps.go-cache-paths.outputs.go-mod }}
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
-      - name: Go Format
-        run: |
-          go fmt ./...
-
       - name: Build
         run: |
           go build ./...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -375,9 +375,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      # Needed for building binaries to generate manpages
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
+      - id: go-cache-paths
+        shell: bash
+        run: |
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+
+      - name: Go Build Cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+
+      - name: Go Mod Cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
       - name: Install make
         run: |
           sudo apt -y install make
+
       - name: Build rpm
         run: |
           make rpm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -405,5 +405,14 @@ jobs:
           sudo apt -y install make
 
       - name: Build rpm
+        id: build-rpm
         run: |
           make rpm
+          echo "artifact-name=$(pwd)/dist/rpm/mock/apex-*.x86_64.rpm" >> $GITHUB_OUTPUT
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: apex
+          path: |
+            ${{ steps.build-rpm.outputs.artifact-name }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,6 +131,31 @@ jobs:
             srpm_distro: fc38
     steps:
       - uses: actions/checkout@v2
+
+      # Needed for building binaries to generate manpages
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
+      - id: go-cache-paths
+        shell: bash
+        run: |
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+
+      - name: Go Build Cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+
+      - name: Go Mod Cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
       - name: Install make
         run: |
           sudo apt -y install make

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,3 +118,28 @@ jobs:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           commit_prefix: "[deploy] "
           commit_message: "Update qa images to ${{ steps.gitsha.outputs.short }}"
+
+  publish-rpms:
+    runs-on: ubuntu-latest
+    environment: copr-repo
+    strategy:
+      matrix:
+        include:
+          - mock_root: fedora-37-x86_64
+            srpm_distro: fc37
+          - mock_root: fedora-38-x86_64
+            srpm_distro: fc38
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install make
+        run: |
+          sudo apt -y install make
+      - name: Build srpm
+        run: |
+          MOCK_ROOT="${{ matrix.mock_root }}" make srpm
+          find dist
+      - name: Submit srpm to copr
+        run: |
+          echo "${{ secrets.COPR_CONFIG }}" > ~/.config/copr
+          docker run --name copr-cli -v $(pwd):/apex -v ~/.config:/root/.config quay.io/apex/mock:latest \
+              copr-cli build apex -r ${{ matrix.mock_root }} --nowait /apex//dist/rpm/mock/apex-0-0.1.$(date +%Y%m%d)git$(git describe --always).${{ matrix.srpm_distro }}.src.rpm

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ kubeconfigs/
 ./deploy/apex-client/overlays/sample/kustomization.yaml
 ./deploy/apex-client/overlays/sample/node_selector.yaml
 
+# Auto generated man pages
+/contrib/man/*

--- a/Containerfile.mock
+++ b/Containerfile.mock
@@ -1,4 +1,4 @@
 FROM fedora:38
 
 RUN dnf -y update
-RUN dnf -y install mock make copr-cli
+RUN dnf -y install mock make copr-cli txt2man groff

--- a/Containerfile.mock
+++ b/Containerfile.mock
@@ -1,4 +1,4 @@
 FROM fedora:38
 
 RUN dnf -y update
-RUN dnf -y install mock make
+RUN dnf -y install mock make copr-cli

--- a/Makefile
+++ b/Makefile
@@ -272,13 +272,15 @@ MOCK_ROOT?=fedora-37-x86_64
 SRPM_DISTRO?=fc37
 
 .PHONY: srpm
-srpm: dist/rpm image-mock ## Build a source RPM
+srpm: dist/rpm image-mock manpages ## Build a source RPM
 	go mod vendor
 	rm -rf dist/rpm/apex-${APEX_RELEASE}
 	rm -f dist/rpm/apex-${APEX_RELEASE}.tar.gz
 	git archive --format=tar.gz -o dist/rpm/apex-${APEX_RELEASE}.tar.gz --prefix=apex-${APEX_RELEASE}/ ${APEX_RELEASE}
 	cd dist/rpm && tar xzf apex-${APEX_RELEASE}.tar.gz
 	mv vendor dist/rpm/apex-${APEX_RELEASE}/.
+	mkdir -p dist/rpm/apex-${APEX_RELEASE}/contrib/man
+	cp -r contrib/man/* dist/rpm/apex-${APEX_RELEASE}/contrib/man/.
 	cd dist/rpm && tar czf apex-${APEX_RELEASE}.tar.gz apex-${APEX_RELEASE} && rm -rf apex-${APEX_RELEASE}
 	cp contrib/rpm/apex.spec.in contrib/rpm/apex.spec
 	sed -i -e "s/##APEX_COMMIT##/${APEX_RELEASE}/" contrib/rpm/apex.spec
@@ -290,8 +292,8 @@ srpm: dist/rpm image-mock ## Build a source RPM
 .PHONY: rpm
 rpm: srpm ## Build an RPM
 	docker run --name mock --rm --privileged=true -v $(CURDIR):/apex quay.io/apex/mock:latest \
-		mock --rebuild --without check \--resultdir=/apex/dist/rpm/mock --root ${MOCK_ROOT} \
-		/apex/$(wildcard dist/rpm/mock/apex-*$(shell date +%Y%m%d)git$(APEX_RELEASE).$(SRPM_DISTRO).src.rpm)
+		mock --rebuild --without check --resultdir=/apex/dist/rpm/mock --root ${MOCK_ROOT} \
+		/apex/$(wildcard dist/rpm/mock/apex-0-0.1.$(shell date --utc +%Y%m%d)git$(APEX_RELEASE).$(SRPM_DISTRO).src.rpm)
 
 ##@ Manpage Generation
 

--- a/Makefile
+++ b/Makefile
@@ -285,14 +285,14 @@ srpm: dist/rpm image-mock manpages ## Build a source RPM
 	cp contrib/rpm/apex.spec.in contrib/rpm/apex.spec
 	sed -i -e "s/##APEX_COMMIT##/${APEX_RELEASE}/" contrib/rpm/apex.spec
 	docker run --name mock --rm --privileged=true -v $(CURDIR):/apex quay.io/apex/mock:latest \
-		mock --buildsrpm -D "_commit ${APEX_RELEASE}" --resultdir=/apex/dist/rpm/mock \
+		mock --buildsrpm -D "_commit ${APEX_RELEASE}" --resultdir=/apex/dist/rpm/mock --no-clean --no-cleanup-after \
 		--spec /apex/contrib/rpm/apex.spec --sources /apex/dist/rpm/ --root ${MOCK_ROOT}
 	rm -f dist/rpm/apex-${APEX_RELEASE}.tar.gz
 
 .PHONY: rpm
 rpm: srpm ## Build an RPM
 	docker run --name mock --rm --privileged=true -v $(CURDIR):/apex quay.io/apex/mock:latest \
-		mock --rebuild --without check --resultdir=/apex/dist/rpm/mock --root ${MOCK_ROOT} \
+		mock --rebuild --without check --resultdir=/apex/dist/rpm/mock --root ${MOCK_ROOT} --no-clean --no-cleanup-after \
 		/apex/$(wildcard dist/rpm/mock/apex-0-0.1.$(shell date --utc +%Y%m%d)git$(APEX_RELEASE).$(SRPM_DISTRO).src.rpm)
 
 ##@ Manpage Generation

--- a/Makefile
+++ b/Makefile
@@ -277,13 +277,13 @@ srpm: dist/rpm image-mock ## Build a source RPM
 	rm -rf dist/rpm/apex-${APEX_RELEASE}
 	rm -f dist/rpm/apex-${APEX_RELEASE}.tar.gz
 	git archive --format=tar.gz -o dist/rpm/apex-${APEX_RELEASE}.tar.gz --prefix=apex-${APEX_RELEASE}/ ${APEX_RELEASE}
-	cd dist/rpm && tar xvzf apex-${APEX_RELEASE}.tar.gz
+	cd dist/rpm && tar xzf apex-${APEX_RELEASE}.tar.gz
 	mv vendor dist/rpm/apex-${APEX_RELEASE}/.
-	cd dist/rpm && tar czvf apex-${APEX_RELEASE}.tar.gz apex-${APEX_RELEASE} && rm -rf apex-${APEX_RELEASE}
+	cd dist/rpm && tar czf apex-${APEX_RELEASE}.tar.gz apex-${APEX_RELEASE} && rm -rf apex-${APEX_RELEASE}
 	cp contrib/rpm/apex.spec.in contrib/rpm/apex.spec
 	sed -i -e "s/##APEX_COMMIT##/${APEX_RELEASE}/" contrib/rpm/apex.spec
 	docker rm -f mock || true
-	docker run --name mock --cap-add SYS_ADMIN -v $(CURDIR):/apex quay.io/apex/mock:latest \
+	docker run --name mock --privileged=true -v $(CURDIR):/apex quay.io/apex/mock:latest \
 		mock --buildsrpm -D "_commit ${APEX_RELEASE}" --resultdir=/apex/dist/rpm/mock \
 		--spec /apex/contrib/rpm/apex.spec --sources /apex/dist/rpm/ --root ${MOCK_ROOT}
 	rm -f dist/rpm/apex-${APEX_RELEASE}.tar.gz
@@ -291,7 +291,7 @@ srpm: dist/rpm image-mock ## Build a source RPM
 .PHONY: rpm
 rpm: srpm ## Build an RPM
 	docker rm -f mock || true
-	docker run --name mock --cap-add SYS_ADMIN -v $(CURDIR):/apex quay.io/apex/mock:latest \
+	docker run --name mock --privileged=true -v $(CURDIR):/apex quay.io/apex/mock:latest \
 		mock --rebuild --without check \--resultdir=/apex/dist/rpm/mock --root ${MOCK_ROOT} \
 		/apex/$(wildcard dist/rpm/mock/apex-*$(shell date +%Y%m%d)git$(APEX_RELEASE).$(SRPM_DISTRO).src.rpm)
 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ clean: ## clean built binaries
 
 .PHONY: go-lint
 go-lint: $(APEXD_DEPS) $(APISERVER_DEPS) ## Lint the go code
-	@if ! which golangci-lint 2>&1 >/dev/null; then \
+	@if ! which golangci-lint >/dev/null 2>&1; then \
 		echo "Please install golangci-lint." ; \
 		echo "See: https://golangci-lint.run/usage/install/#local-installation" ; \
 		exit 1 ; \
@@ -69,7 +69,7 @@ go-lint: $(APEXD_DEPS) $(APISERVER_DEPS) ## Lint the go code
 
 .PHONY: yaml-lint
 yaml-lint: ## Lint the yaml files
-	@if ! which yamllint 2>&1 >/dev/null; then \
+	@if ! which yamllint >/dev/null 2>&1; then \
 		echo "Please install yamllint." ; \
 		echo "See: https://yamllint.readthedocs.io/en/stable/quickstart.html" ; \
 		exit 1 ; \
@@ -282,18 +282,26 @@ srpm: dist/rpm image-mock ## Build a source RPM
 	cd dist/rpm && tar czf apex-${APEX_RELEASE}.tar.gz apex-${APEX_RELEASE} && rm -rf apex-${APEX_RELEASE}
 	cp contrib/rpm/apex.spec.in contrib/rpm/apex.spec
 	sed -i -e "s/##APEX_COMMIT##/${APEX_RELEASE}/" contrib/rpm/apex.spec
-	docker rm -f mock || true
-	docker run --name mock --privileged=true -v $(CURDIR):/apex quay.io/apex/mock:latest \
+	docker run --name mock --rm --privileged=true -v $(CURDIR):/apex quay.io/apex/mock:latest \
 		mock --buildsrpm -D "_commit ${APEX_RELEASE}" --resultdir=/apex/dist/rpm/mock \
 		--spec /apex/contrib/rpm/apex.spec --sources /apex/dist/rpm/ --root ${MOCK_ROOT}
 	rm -f dist/rpm/apex-${APEX_RELEASE}.tar.gz
 
 .PHONY: rpm
 rpm: srpm ## Build an RPM
-	docker rm -f mock || true
-	docker run --name mock --privileged=true -v $(CURDIR):/apex quay.io/apex/mock:latest \
+	docker run --name mock --rm --privileged=true -v $(CURDIR):/apex quay.io/apex/mock:latest \
 		mock --rebuild --without check \--resultdir=/apex/dist/rpm/mock --root ${MOCK_ROOT} \
 		/apex/$(wildcard dist/rpm/mock/apex-*$(shell date +%Y%m%d)git$(APEX_RELEASE).$(SRPM_DISTRO).src.rpm)
+
+##@ Manpage Generation
+
+contrib/man:
+	$(CMD_PREFIX) mkdir -p contrib/man
+
+.PHONY: manpages
+manpages: contrib/man dist/apexd dist/apexctl image-mock ## Generate manpages in ./contrib/man
+	dist/apexd -h | docker run -i --rm --name txt2man quay.io/apex/mock:latest txt2man -t apexd | gzip > contrib/man/apexd.8.gz
+	dist/apexctl -h | docker run -i --rm --name txt2man quay.io/apex/mock:latest txt2man -t apexctl | gzip > contrib/man/apexctl.8.gz
 
 # Nothing to see here
 .PHONY: cat

--- a/contrib/rpm/apex.service
+++ b/contrib/rpm/apex.service
@@ -9,4 +9,4 @@ Restart=always
 RestartSec=1
 User=root
 EnvironmentFile=/etc/sysconfig/apex
-ExecStart=/usr/bin/apexd ${APEX_ARGS} ${APEX_URL}
+ExecStart=/usr/bin/apexd ${APEX_URL} ${APEX_ARGS}

--- a/contrib/rpm/apex.spec.in
+++ b/contrib/rpm/apex.spec.in
@@ -37,6 +37,7 @@ Source:         apex-##APEX_COMMIT##.tar.gz
 %description %{common_description}
 
 BuildRequires: systemd-rpm-macros
+BuildRequires: systemd-units
 Requires: wireguard-tools
 Requires(post): systemd-units
 Requires(preun): systemd-units
@@ -65,6 +66,9 @@ install -m 0755 -vp %{gobuilddir}/bin/* %{buildroot}%{_bindir}/
 install -p -D -m 0644 contrib/rpm/apex.service %{buildroot}%{_libdir}/systemd/system/apex.service
 #install -p -D -m 0644 contrib/rpm/apex.service %{buildroot}%{_unitdir}/apex.service
 install -p -D -m 0644 contrib/rpm/apex.sysconfig %{buildroot}%{_sysconfdir}/sysconfig/apex
+for cmd in apexd apexctl ; do
+  install -p -D -m 0644 contrib/man/${cmd}.8.gz %{buildroot}%{_mandir}/man8/${cmd}.8.gz
+done
 
 %if %{with check}
 %check
@@ -78,17 +82,36 @@ install -p -D -m 0644 contrib/rpm/apex.sysconfig %{buildroot}%{_sysconfdir}/sysc
 %{_libdir}/systemd/system/apex.service
 #%{_unitdir}/apex.service
 %{_sysconfdir}/sysconfig/apex
+%{_mandir}/man8/*
 
 %gopkgfiles
 
 %post
-%systemd_post apex.service
+%if 0%{?systemd_post:1}
+    %systemd_post apex.service
+%else
+    if [ $1 -eq 1 ]; then
+        /bin/systemctl daemon-reload >/dev/null || :
+    fi
+%endif
 
 %preun
-%systemd_preun apex.service
+%if 0%{?systemd_preun:1}
+  %systemd_preun apex.service
+%else
+  if [ $1 -eq 0 ] ; then
+    # Package removal, not upgrade
+    /bin/systemctl --no-reload disable apex.service >/dev/null 2>&1 || :
+    /bin/systemctl stop apex.service >/dev/null 2>&1 || :
+  fi
+%endif
 
 %postun
-%systemd_postun apex.service
+%if 0%{?systemd_postun:1}
+  %systemd_postun apex.service
+%else
+  /bin/systemctl daemon-reload >/dev/null 2>&1 || :
+%endif
 
 %changelog
 %autochangelog

--- a/contrib/rpm/apex.spec.in
+++ b/contrib/rpm/apex.spec.in
@@ -63,8 +63,7 @@ done
 %gopkginstall
 install -m 0755 -vd                     %{buildroot}%{_bindir}
 install -m 0755 -vp %{gobuilddir}/bin/* %{buildroot}%{_bindir}/
-install -p -D -m 0644 contrib/rpm/apex.service %{buildroot}%{_libdir}/systemd/system/apex.service
-#install -p -D -m 0644 contrib/rpm/apex.service %{buildroot}%{_unitdir}/apex.service
+install -p -D -m 0644 contrib/rpm/apex.service %{buildroot}/usr/lib/systemd/system/apex.service
 install -p -D -m 0644 contrib/rpm/apex.sysconfig %{buildroot}%{_sysconfdir}/sysconfig/apex
 for cmd in apexd apexctl ; do
   install -p -D -m 0644 contrib/man/${cmd}.8.gz %{buildroot}%{_mandir}/man8/${cmd}.8.gz
@@ -79,8 +78,7 @@ done
 %license LICENSE
 %doc docs DCO CONTRIBUTING.md README.md
 %{_bindir}/*
-%{_libdir}/systemd/system/apex.service
-#%{_unitdir}/apex.service
+/usr/lib/systemd/system/apex.service
 %{_sysconfdir}/sysconfig/apex
 %{_mandir}/man8/*
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,8 @@
     - [Deploying on Node](#deploying-on-node)
       - [Installing the Agent](#installing-the-agent)
         - [Install Script](#install-script)
-        - [RPM](#rpm)
+        - [RPM from a Copr Repository](#rpm-from-a-copr-repository)
+        - [Custom RPM Build](#custom-rpm-build)
         - [Systemd](#systemd)
         - [Starting the Agent](#starting-the-agent)
       - [Interactive Enrollment](#interactive-enrollment)
@@ -152,9 +153,25 @@ The `hack/apex_installer.sh` script will download the latest build of `apexd` an
 hack/apex_installer.sh
 ```
 
-##### RPM
+##### RPM from a Copr Repository
 
-You can build an rpm from the git repository. The rpm will include `apexctl`, `apexd`, and integration with systemd. You must have `mock` installed to build the package.
+A Fedora [Copr repository](https://copr.fedorainfracloud.org/coprs/russellb/apex/) is updated with new rpms after each new commit to the `main` branch that passes CI. The rpm will include `apexctl`, `apexd`, and integration with systemd.
+
+You can add this repository to your Fedora host with the following command:
+
+```sh
+sudo dnf copr enable russellb/apex
+```
+
+Then you should be able to install apex with:
+
+```sh
+sudo dnf install apex
+```
+
+##### Custom RPM Build
+
+You can also build a custom rpm from the git repository. You must have `mock` installed to build the package.
 
 ```sh
 make rpm


### PR DESCRIPTION
```
commit 2d944741186134f7b77be3eebecab4f30804df37
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Feb 20 20:49:36 2023 -0500

    rpm: Package the manpages
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 629050c550e1809b8df20cfcf3ec678e4d88d69a
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Feb 20 18:02:41 2023 -0500

    Makefile: Add manpage generation
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit cf644df5a14467d920128948c1274803e29c6964
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Feb 20 17:11:44 2023 -0500

    docs: Document how to use the copr repo for rpms
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 33e8f3dbf5b1f9b78a1f765e0f59575565ff2faf
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Feb 20 14:20:33 2023 -0500

    ci: Publish rpms to a copr repo
    
    This PR sets up a job to publish new RPMs to a copr repo for each new
    commit to the main branch
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 96e59dd36dcb333d28a3d7d750e0f50eefd9c08f
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Feb 17 12:42:58 2023 -0500

    ci: Add an rpm build job
    
    Ensure the rpm build is functional via CI. --cap-add SYS_ADMIN didn't
    work in CI for some reason, so I switched to a privileged container. I
    also made the build a little less noisy.
    
    Closes #436
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 2b3df2803fcf4736043eff2112f55623cc8ebed7
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Feb 20 11:26:05 2023 -0500

    ci: Split unit tests out into their own job
    
    I was surprised to see the unit tests running in the lint job. This
    patch splits them out into their own job that runs after lint passes.
    
    This change also renames `lint` to `go-lint` to make the job name more
    explicit about the type of linting it is doing.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 48ca3d6858087e1664f4d50aa413ed6d189dc957
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Feb 20 11:23:32 2023 -0500

    ci: Stop running go fmt
    
    This command silently fixes any formatting issues before running the
    linter. We should let the linter find the issues and then fail the CI
    job.

    Signed-off-by: Russell Bryant <rbryant@redhat.com>
```