### PR TITLE
Use golang-1.19 image, instead of golang-1.19-alpine

### DIFF
--- a/Containerfile.apex
+++ b/Containerfile.apex
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.19-alpine as build-apex
+FROM docker.io/library/golang:1.19 as build-apex
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -12,7 +12,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
     -ldflags="-extldflags=-static" \
     -o apexd ./cmd/apexd
 
-FROM docker.io/library/golang:1.19-alpine as build-mkcert
+FROM docker.io/library/golang:1.19 as build-mkcert
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
Apex agent container image build is failing for windows platform, because the docker container 
file is using golang-1.19-alpine image to build the  binary, and obviously it's doesn't support windows/amd64-arm64
arch.