### PR TITLE
ci: Don't build windows images

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/amd64,linux/arm64, windows/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           file: ./Containerfile.apex
           tags: |


### PR DESCRIPTION
You can't build windows containers from a linux worker