### PR TITLE
Revert "Apex agent container image build is failing for"

### DIFF
--- a/Containerfile.apex
+++ b/Containerfile.apex
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.19 as build-apex
+FROM docker.io/library/golang:1.19-alpine as build-apex
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -12,7 +12,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
     -ldflags="-extldflags=-static" \
     -o apexd ./cmd/apexd
 
-FROM docker.io/library/golang:1.19 as build-mkcert
+FROM docker.io/library/golang:1.19-alpine as build-mkcert
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
This reverts commit 85a479cac8ff4562273950d6d7cedb7b967a2e73.

Switch back to the alpine-based image, as our jobs assume alpine tools for installing things. A later commit disabling windows builds on linux workers was the fix needed.