### PR TITLE
Apex image build job moved from go-1.19-alpine

### DIFF
--- a/Containerfile.apex
+++ b/Containerfile.apex
@@ -17,8 +17,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 WORKDIR /
-RUN apk add git && \
-    git clone https://github.com/FiloSottile/mkcert && cd mkcert && \
+RUN git clone https://github.com/FiloSottile/mkcert && cd mkcert && \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
     -ldflags "-extldflags=-static -X main.Version=$(git describe --tags)"
 


### PR DESCRIPTION
image to go-1.19 image to enable windows support.
That breaks the command to build the mkcert util
and this patch fixes it.