### PR TITLE
Faster make deploy and recreate db

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 ui/node_modules
 Makefile
 !**/rootCA.pem
+Containerfile.*
+dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -293,10 +293,17 @@ jobs:
           name: frontend
           path: /tmp
 
+      - name: Download ipam image
+        uses: actions/download-artifact@v3
+        with:
+          name: ipam
+          path: /tmp
+
       - name: Load Docker images
         run: |
           docker load --input /tmp/apiserver.tar
           docker load --input /tmp/frontend.tar
+          docker load --input /tmp/ipam.tar
 
       - name: Build dist
         run: |
@@ -304,7 +311,7 @@ jobs:
 
       - name: Setup KIND
         run: |
-          make run-on-kind
+          make setup-kind deploy-operators load-images deploy cacerts
 
       - name: Build ubuntu test image
         uses: docker/build-push-action@v4
@@ -317,9 +324,21 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Run e2e
+      - name: Run e2e against Crunchy managed Postgres
         run: |
           go test -v --tags=integration ./integration-tests/...
+
+# TODO: one day, uncomment this so that we also verify that the e2e
+#       tests work against Cockroach DB too.
+#
+#      - name: Switch to Cockroach DB
+#        run: |
+#          make use-cockroach
+#
+#      - name: Run e2e against Cockroach DB
+#        run: |
+#          go clean -testcache
+#          go test -v --tags=integration ./integration-tests/...
 
       - name: Get Logs
         if: always()

--- a/Containerfile.test
+++ b/Containerfile.test
@@ -1,9 +1,33 @@
+FROM docker.io/library/golang:1.19-alpine as build
+
+WORKDIR /src
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 go build \
+    -ldflags="-extldflags=-static" \
+    -o ./dist/apexd ./cmd/apexd
+RUN CGO_ENABLED=0 go build \
+    -ldflags="-extldflags=-static" \
+    -o ./dist/apexctl ./cmd/apexctl
+
 FROM alpine:3.16 as alpine
-RUN apk add --no-cache iputils wireguard-tools iptables psmisc ca-certificates
-COPY ./dist/apexd /bin/apexd
-COPY ./dist/apexctl /bin/apexctl
+RUN apk add --no-cache \
+    iputils \
+    wireguard-tools \
+    iptables \
+    psmisc \
+    ca-certificates
+COPY --from=build /src/dist/apexd /bin/apexd
+COPY --from=build /src/dist/apexctl /bin/apexctl
 COPY ./.certs/rootCA.pem /usr/local/share/ca-certificates/rootCA.crt
 RUN /usr/sbin/update-ca-certificates
+RUN echo 'echo "To connect this container to the apex network, try running:"' >> /root/.bashrc &&\
+    echo 'echo' >> /root/.bashrc &&\
+    echo 'echo "   /bin/apexd --username admin --password floofykittens https://apex.local"' >> /root/.bashrc &&\
+    echo 'echo' >> /root/.bashrc
 ENTRYPOINT [ "/bin/sleep", "infinity" ]
 
 FROM fedora:36 as fedora
@@ -19,10 +43,14 @@ RUN dnf update -qy && \
     hostname \
     && \
     dnf clean all
-COPY ./dist/apexd /bin/apexd
-COPY ./dist/apexctl /bin/apexctl
+COPY --from=build /src/dist/apexd /bin/apexd
+COPY --from=build /src/dist/apexctl /bin/apexctl
 COPY ./.certs/rootCA.pem /etc/pki/ca-trust/source/anchors/rootCA.crt
 RUN /usr/bin/update-ca-trust
+RUN echo 'echo "To connect this container to the apex network, try running:"' >> /root/.bashrc &&\
+    echo 'echo' >> /root/.bashrc &&\
+    echo 'echo "   /bin/apexd --username admin --password floofykittens https://apex.local"' >> /root/.bashrc &&\
+    echo 'echo' >> /root/.bashrc
 ENTRYPOINT [ "/bin/sleep", "infinity" ]
 
 FROM ubuntu:22.04 as ubuntu
@@ -41,14 +69,12 @@ RUN apt-get update -qy && \
     psmisc \
     && \
     apt-get clean
-COPY ./dist/apexd /bin/apexd
-COPY ./dist/apexctl /bin/apexctl
+COPY --from=build /src/dist/apexd /bin/apexd
+COPY --from=build /src/dist/apexctl /bin/apexctl
 COPY ./.certs/rootCA.pem /usr/local/share/ca-certificates/rootCA.crt
 RUN /usr/sbin/update-ca-certificates
-RUN echo "echo '\n\
-To connect this container to the apex network, try running:\n\
-\n\
-   /bin/apexd --username admin --password floofykittens https://apex.local\n\
-'" >> /root/.bashrc
-
+RUN echo 'echo "To connect this container to the apex network, try running:"' >> /root/.bashrc &&\
+    echo 'echo' >> /root/.bashrc &&\
+    echo 'echo "   /bin/apexd --username admin --password floofykittens https://apex.local"' >> /root/.bashrc &&\
+    echo 'echo' >> /root/.bashrc
 ENTRYPOINT [ "/bin/sleep", "infinity" ]

--- a/deploy/apex/overlays/cockroach/kustomization.yaml
+++ b/deploy/apex/overlays/cockroach/kustomization.yaml
@@ -23,6 +23,14 @@ secretGenerator:
       - port=26257
       - user=apiserver
 
+  - name: database-pguser-keycloak
+    literals:
+      - host=postgres
+      - port=5432
+      - user=keycloak
+      - password=password
+      - dbname=keycloak
+
 configMapGenerator:
   - name: ipam
     behavior: merge


### PR DESCRIPTION
This also pegs the build to a specific revision of crunchy db and makes the test container multi-arch.