### PR TITLE
feat: mount the .certs directory into the test container image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,6 +193,21 @@ jobs:
           name: ipam
           path: /tmp/ipam.tar
 
+      - name: Build and export ipam
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Containerfile.test
+          tags: quay.io/apex/test:ubuntu
+          outputs: type=docker,dest=/tmp/test-ubuntu.tar
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Upload test:ubuntu artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-ubuntu
+          path: /tmp/test-ubuntu.tar
+
   build-binaries:
     needs: go-lint
     strategy:
@@ -328,11 +343,18 @@ jobs:
           name: ipam
           path: /tmp
 
+      - name: Download test:ubuntu image
+        uses: actions/download-artifact@v3
+        with:
+          name: test-ubuntu
+          path: /tmp
+
       - name: Load Docker images
         run: |
           docker load --input /tmp/apiserver.tar
           docker load --input /tmp/frontend.tar
           docker load --input /tmp/ipam.tar
+          docker load --input /tmp/test-ubuntu.tar
 
       - name: Build dist
         run: |
@@ -341,17 +363,6 @@ jobs:
       - name: Setup KIND
         run: |
           make setup-kind deploy-operators load-images deploy cacerts
-
-      - name: Build ubuntu test image
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: ./Containerfile.test
-          target: ubuntu
-          tags: quay.io/apex/test:ubuntu
-          load: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Run e2e against Crunchy managed Postgres
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,7 @@ jobs:
         run: |
           mkdir -p $HOME/.local/bin
           pushd $HOME/.local/bin
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s 4.5.7
+          curl -s --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s 4.5.7
           popd
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 

--- a/Containerfile.test
+++ b/Containerfile.test
@@ -22,13 +22,10 @@ RUN apk add --no-cache \
     ca-certificates
 COPY --from=build /src/dist/apexd /bin/apexd
 COPY --from=build /src/dist/apexctl /bin/apexctl
-COPY ./.certs/rootCA.pem /usr/local/share/ca-certificates/rootCA.crt
-RUN /usr/sbin/update-ca-certificates
-RUN echo 'echo "To connect this container to the apex network, try running:"' >> /root/.bashrc &&\
-    echo 'echo' >> /root/.bashrc &&\
-    echo 'echo "   /bin/apexd --username admin --password floofykittens https://apex.local"' >> /root/.bashrc &&\
-    echo 'echo' >> /root/.bashrc
-ENTRYPOINT [ "/bin/sleep", "infinity" ]
+COPY ./hack/test-container-boot.sh /boot.sh
+RUN chmod a+x /boot.sh &&\
+    echo '/boot.sh' >> /root/.bashrc
+ENTRYPOINT [ "/boot.sh", "/bin/sleep", "infinity" ]
 
 FROM fedora:36 as fedora
 RUN dnf update -qy && \
@@ -45,13 +42,10 @@ RUN dnf update -qy && \
     dnf clean all
 COPY --from=build /src/dist/apexd /bin/apexd
 COPY --from=build /src/dist/apexctl /bin/apexctl
-COPY ./.certs/rootCA.pem /etc/pki/ca-trust/source/anchors/rootCA.crt
-RUN /usr/bin/update-ca-trust
-RUN echo 'echo "To connect this container to the apex network, try running:"' >> /root/.bashrc &&\
-    echo 'echo' >> /root/.bashrc &&\
-    echo 'echo "   /bin/apexd --username admin --password floofykittens https://apex.local"' >> /root/.bashrc &&\
-    echo 'echo' >> /root/.bashrc
-ENTRYPOINT [ "/bin/sleep", "infinity" ]
+COPY ./hack/test-container-boot.sh /boot.sh
+RUN chmod a+x /boot.sh &&\
+    echo '/boot.sh' >> /root/.bashrc
+ENTRYPOINT [ "/boot.sh", "/bin/sleep", "infinity" ]
 
 FROM ubuntu:22.04 as ubuntu
 ENV DEBIAN_FRONTEND=noninteractive
@@ -71,10 +65,7 @@ RUN apt-get update -qy && \
     apt-get clean
 COPY --from=build /src/dist/apexd /bin/apexd
 COPY --from=build /src/dist/apexctl /bin/apexctl
-COPY ./.certs/rootCA.pem /usr/local/share/ca-certificates/rootCA.crt
-RUN /usr/sbin/update-ca-certificates
-RUN echo 'echo "To connect this container to the apex network, try running:"' >> /root/.bashrc &&\
-    echo 'echo' >> /root/.bashrc &&\
-    echo 'echo "   /bin/apexd --username admin --password floofykittens https://apex.local"' >> /root/.bashrc &&\
-    echo 'echo' >> /root/.bashrc
-ENTRYPOINT [ "/bin/sleep", "infinity" ]
+COPY ./hack/test-container-boot.sh /boot.sh
+RUN chmod a+x /boot.sh &&\
+    echo '/boot.sh' >> /root/.bashrc
+ENTRYPOINT [ "/boot.sh", "/bin/sleep", "infinity" ]

--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,9 @@ test: ## Run unit tests
 
 APEX_LOCAL_IP:=`go run ./hack/resolve-ip apex.local`
 .PHONY: run-test-container
+TEST_CONTAINER_DISTRO?=ubuntu
 run-test-container: ## Run docker container that you can run apex in
-	@docker build -f Containerfile.test -t quay.io/apex/test:ubuntu --target ubuntu .
+	@docker build -f Containerfile.test -t quay.io/apex/test:$(TEST_CONTAINER_DISTRO) --target $(TEST_CONTAINER_DISTRO) .
 	@docker run --rm -it --network bridge \
 		--cap-add SYS_MODULE \
 		--cap-add NET_ADMIN \
@@ -118,7 +119,8 @@ run-test-container: ## Run docker container that you can run apex in
 		--add-host apex.local:$(APEX_LOCAL_IP) \
 		--add-host api.apex.local:$(APEX_LOCAL_IP) \
 		--add-host auth.apex.local:$(APEX_LOCAL_IP) \
-		--entrypoint /bin/bash quay.io/apex/test:ubuntu
+		--mount type=bind,source=$(shell pwd)/.certs,target=/.certs,readonly \
+		--entrypoint /bin/bash quay.io/apex/test:$(TEST_CONTAINER_DISTRO)
 
 ##@ Container Images
 

--- a/hack/test-container-boot.sh
+++ b/hack/test-container-boot.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+if [ -f /.certs/rootCA.pem ]; then
+  if [ -x /usr/sbin/update-ca-certificates ]; then
+    cp /.certs/rootCA.pem /usr/local/share/ca-certificates/rootCA.crt
+    /usr/sbin/update-ca-certificates
+  elif [ -x /usr/bin/update-ca-trust ]; then
+    cp ./.certs/rootCA.pem /etc/pki/ca-trust/source/anchors/rootCA.crt
+    /usr/bin/update-ca-trust
+  else
+    echo "error: unable to add root CA certificate"
+    exit 1
+  fi
+fi
+if [ -z "$1" ]; then
+  exec $*
+fi
+echo "To connect this container to the apex network, try running:"
+echo
+echo "   /bin/apexd --username admin --password floofykittens https://apex.local"
+echo
+


### PR DESCRIPTION
instead of building the certs into it.

This will allow the same image usable with any install of the apex service.