### PR TITLE
docs: Add a doc on pull request process

### DIFF
--- a/docs/governance/pull-requests.md
+++ b/docs/governance/pull-requests.md
@@ -1,0 +1,25 @@
+# Pull Requests
+
+Contributions to this repository are accepted via GitHub Pull Requests.
+
+## Commit Messages
+
+### DCO and Signed-off-by
+
+When contributing changes to this project, you must agree to the [DCO](DCO).
+Commits must include a `Signed-off-by:` header which certifies agreement with
+the terms of the [DCO](DCO).
+
+Using `-s` with `git commit` will automtaically add this header.
+
+## Merge Criteria
+
+Pull requests should receive at least one approval before merging. CI should also be passing. You may enable the [auto-merge feature](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request) on a PR to have it be automatically merged once this criteria has been met.
+
+## Requesting Reviews
+
+Use the GitHub reviewers field to request reviews from a specific individual. Be sure to also select "re-request review" after making changes in response to a past review to ensure the reviewer knows it's ready for another look.
+
+## Exceptions
+
+These are guidelines, not hard rules. Committers have earned the trust of others to use their best judgement in each situation.


### PR DESCRIPTION
Start a doc where we can document our guidelines for handling pull requests. This will help ensure a shared understanding of what we expect from each other as project committers.