### PR TITLE
deploy: Check for new commits to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,6 +126,11 @@ jobs:
         run: |
           git diff --quiet || echo "COMMIT_CHANGES=1" >> $GITHUB_ENV
 
+      - name: Check for new commits in main
+        run: |
+          git fetch origin
+          if [ "$(git log HEAD..origin/main --oneline | wc -l)" != "0" ]; then echo "COMMIT_CHANGES=0"; fi >> $GITHUB_ENV
+
       - name: Commit Changes
         id: commit
         if: env.COMMIT_CHANGES == 1


### PR DESCRIPTION
The deploy workflow fails often if additional PRs have been merged by the time this job runs. This change will check to see if there are any commits in main that are not in the branch the job is running on. If so, it will not attempt to push a commit that would fail.