### PR TITLE
lint: Make md-lint check the whole project

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,3 +23,5 @@ jobs:
       - uses: actions/checkout@v3
       - name: markdownlint-cli2-action
         uses: DavidAnson/markdownlint-cli2-action@v9
+        with:
+          globs: '**/*.md'

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ endif
 ##@ All
 
 .PHONY: all
-all: go-lint yaml-lint markdown-lint ui-lint apexd apexctl ## Run linters and build apexd
+all: go-lint yaml-lint md-lint ui-lint apexd apexctl ## Run linters and build apexd
 
 ##@ Binaries
 
@@ -99,8 +99,8 @@ yaml-lint: ## Lint the yaml files
 	$(ECHO_PREFIX) printf "  %-12s ./...\n" "[YAML LINT]"
 	$(CMD_PREFIX) yamllint -c .yamllint.yaml deploy --strict
 
-.PHONY: markdown-lint
-markdown-lint: ## Lint markdown files
+.PHONY: md-lint
+md-lint: ## Lint markdown files
 	$(ECHO_PREFIX) printf "  %-12s ./...\n" "[MD LINT]"
 	$(CMD_PREFIX) docker run -v $(CURDIR):/workdir docker.io/davidanson/markdownlint-cli2:v0.6.0 "**/*.md" "#ui/node_modules" > /dev/null
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@
         - [Starting the Agent](#starting-the-agent)
       - [Interactive Enrollment](#interactive-enrollment)
       - [Verifying Agent Setup](#verifying-agent-setup)
-      - [Verifying Zone Connectivity](#verifying-zone-connectivity)
+      - [Verifying Organization Connectivity](#verifying-organization-connectivity)
       - [Cleanup Agent From Node](#cleanup-agent-from-node)
     - [Deploying on Kubernetes managed Node](#deploying-on-kubernetes-managed-node)
       - [Setup the configuration](#setup-the-configuration)
@@ -31,12 +31,9 @@
       - [Cleanup Agent Pod From Node](#cleanup-agent-pod-from-node)
   - [Deploying the Apex Relay](#deploying-the-apex-relay)
     - [Setup Apex Relay Node](#setup-apex-relay-node)
-    - [Create a Relay Enabled Zone](#create-a-relay-enabled-zone)
-    - [Move user to Relay Enabled Zone](#move-user-to-relay-enabled-zone)
-    - [OnBoard the Relay node to the Relay Enabled Zone](#onboard-the-relay-node-to-the-relay-enabled-zone)
       - [Interactive OnBoarding](#interactive-onboarding)
       - [Silent OnBoarding](#silent-onboarding)
-    - [Delete Zone](#delete-zone)
+    - [Delete Organization](#delete-organization)
   - [Additional Features](#additional-features)
     - [Subnet Routers](#subnet-routers)
   - [Running the integration tests](#running-the-integration-tests)
@@ -414,7 +411,6 @@ You can list the available organizations using following command
 ORGANIZATION ID                          NAME          CIDR              DESCRIPTION                RELAY/HUB ENABLED
 dcab6a84-f522-4e9b-a221-8752d505fc18     default       100.100.1.0/20     Default Zone               false
 ```
-
 
 #### Interactive OnBoarding
 


### PR DESCRIPTION
The default config of this job only checked the root directory, so everything in docs/ was not checked in CI.

Fix some md-lint issues in docs/README.md.

Shorten the Makefile target name to md-lint.